### PR TITLE
feat: implement XDG Base Directory Specification compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ oboyu version
 
 ## Configuration
 
-Create a configuration file at `~/.oboyu/config.yaml`:
+Create a configuration file at the XDG-compliant location `~/.config/oboyu/config.yaml`:
 
 ```yaml
 # Crawler settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ oboyu = "oboyu.cli.main:run"
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/oboyu"]
+
 [dependency-groups]
 dev = [
     "mypy>=1.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pyyaml>=6.0", # YAML configuration file handling # Model Context Protocol for AI assistant integration
     "mcp[cli]>=0.3.0",
     "gitignore-parser>=0.1.11", # Support for respecting .gitignore files
+    "xdg-base-dirs>=6.0.2",
 ]
 
 [project.scripts]

--- a/src/oboyu/cli/paths.py
+++ b/src/oboyu/cli/paths.py
@@ -4,23 +4,22 @@ This module provides centralized path definitions for the application,
 following the XDG Base Directory specification.
 """
 
-import os
-from pathlib import Path
 
-# XDG Base Directory environment variables with defaults
-XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
-XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
-XDG_CACHE_HOME = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
-XDG_STATE_HOME = os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local" / "state"))
+from xdg_base_dirs import (
+    xdg_cache_home,
+    xdg_config_home,
+    xdg_data_home,
+    xdg_state_home,
+)
 
 # Application name
 APP_NAME = "oboyu"
 
 # Base directories for different types of data
-CONFIG_BASE_DIR = Path(XDG_CONFIG_HOME) / APP_NAME
-DATA_BASE_DIR = Path(XDG_DATA_HOME) / APP_NAME
-CACHE_BASE_DIR = Path(XDG_CACHE_HOME) / APP_NAME
-STATE_BASE_DIR = Path(XDG_STATE_HOME) / APP_NAME
+CONFIG_BASE_DIR = xdg_config_home() / APP_NAME
+DATA_BASE_DIR = xdg_data_home() / APP_NAME
+CACHE_BASE_DIR = xdg_cache_home() / APP_NAME
+STATE_BASE_DIR = xdg_state_home() / APP_NAME
 
 # Configuration file path
 DEFAULT_CONFIG_PATH = CONFIG_BASE_DIR / "config.yaml"

--- a/src/oboyu/cli/paths.py
+++ b/src/oboyu/cli/paths.py
@@ -4,26 +4,40 @@ This module provides centralized path definitions for the application,
 following the XDG Base Directory specification.
 """
 
+import os
 from pathlib import Path
 
-# Base config directory path (following XDG Base Directory specification)
-CONFIG_BASE_DIR = Path.home() / ".config" / "oboyu"
+# XDG Base Directory environment variables with defaults
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+XDG_CACHE_HOME = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
+XDG_STATE_HOME = os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local" / "state"))
 
-# Default configuration file path
+# Application name
+APP_NAME = "oboyu"
+
+# Base directories for different types of data
+CONFIG_BASE_DIR = Path(XDG_CONFIG_HOME) / APP_NAME
+DATA_BASE_DIR = Path(XDG_DATA_HOME) / APP_NAME
+CACHE_BASE_DIR = Path(XDG_CACHE_HOME) / APP_NAME
+STATE_BASE_DIR = Path(XDG_STATE_HOME) / APP_NAME
+
+# Configuration file path
 DEFAULT_CONFIG_PATH = CONFIG_BASE_DIR / "config.yaml"
 
-# Default database file path
-DEFAULT_DB_PATH = CONFIG_BASE_DIR / "oboyu.db"
+# Database file path
+DEFAULT_DB_PATH = DATA_BASE_DIR / "index.db"
 
 # Embedding models and cache directory
-EMBEDDING_DIR = CONFIG_BASE_DIR / "embedding"
-EMBEDDING_MODELS_DIR = EMBEDDING_DIR / "models"
-EMBEDDING_CACHE_DIR = EMBEDDING_DIR / "cache"
+EMBEDDING_MODELS_DIR = DATA_BASE_DIR / "embedding" / "models"
+EMBEDDING_CACHE_DIR = CACHE_BASE_DIR / "embedding" / "cache"
 
-# Helper function to ensure config directories exist
+# Helper function to ensure all required directories exist
 def ensure_config_dirs() -> None:
-    """Ensure that the necessary config directories exist."""
+    """Ensure all required directories exist."""
     CONFIG_BASE_DIR.mkdir(parents=True, exist_ok=True)
-    EMBEDDING_DIR.mkdir(parents=True, exist_ok=True)
+    DATA_BASE_DIR.mkdir(parents=True, exist_ok=True)
+    CACHE_BASE_DIR.mkdir(parents=True, exist_ok=True)
+    STATE_BASE_DIR.mkdir(parents=True, exist_ok=True)
     EMBEDDING_MODELS_DIR.mkdir(parents=True, exist_ok=True)
     EMBEDDING_CACHE_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/oboyu/indexer/embedding.py
+++ b/src/oboyu/indexer/embedding.py
@@ -17,15 +17,8 @@ from numpy.typing import NDArray
 from sentence_transformers import SentenceTransformer
 from torch import Tensor
 
+from oboyu.cli.paths import EMBEDDING_CACHE_DIR, EMBEDDING_MODELS_DIR
 from oboyu.indexer.processor import Chunk
-
-# Default embedding directories
-EMBEDDING_CACHE_DIR = Path.home() / ".config" / "oboyu" / "embedding" / "cache"
-EMBEDDING_MODELS_DIR = Path.home() / ".config" / "oboyu" / "embedding" / "models"
-
-# Ensure directories exist
-EMBEDDING_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-EMBEDDING_MODELS_DIR.mkdir(parents=True, exist_ok=True)
 
 # Silence SentenceTransformer logging (INFO level is too verbose)
 logging.getLogger('sentence_transformers').setLevel(logging.ERROR)

--- a/uv.lock
+++ b/uv.lock
@@ -603,6 +603,7 @@ dependencies = [
     { name = "torch" },
     { name = "transformers" },
     { name = "typer" },
+    { name = "xdg-base-dirs" },
 ]
 
 [package.dev-dependencies]
@@ -630,6 +631,7 @@ requires-dist = [
     { name = "torch" },
     { name = "transformers", specifier = ">=4.48.0" },
     { name = "typer", specifier = ">=0.9.0" },
+    { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1293,4 +1295,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316, upload_time = "2025-05-08T17:58:23.811Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982, upload_time = "2025-05-08T17:58:21.15Z" },
+]
+
+[[package]]
+name = "xdg-base-dirs"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/d0/bbe05a15347538aaf9fa5b51ac3b97075dfb834931fcb77d81fbdb69e8f6/xdg_base_dirs-6.0.2.tar.gz", hash = "sha256:950504e14d27cf3c9cb37744680a43bf0ac42efefc4ef4acf98dc736cab2bced", size = 4085, upload_time = "2024-10-19T14:35:08.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/03/030b47fd46b60fc87af548e57ff59c2ca84b2a1dadbe721bb0ce33896b2e/xdg_base_dirs-6.0.2-py3-none-any.whl", hash = "sha256:3c01d1b758ed4ace150ac960ac0bd13ce4542b9e2cdf01312dcda5012cfebabe", size = 4747, upload_time = "2024-10-19T14:35:05.931Z" },
 ]


### PR DESCRIPTION
## Summary

This PR implements full XDG Base Directory Specification compliance as outlined in issue #23.

### Changes Made:
- **Updated `src/oboyu/cli/paths.py`** to use proper XDG environment variables (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, `XDG_STATE_HOME`) with standard fallback paths
- **Reorganized file locations** following XDG spec:
  - Configuration files: `$XDG_CONFIG_HOME/oboyu/` (default: `~/.config/oboyu/`)
  - Database files: `$XDG_DATA_HOME/oboyu/` (default: `~/.local/share/oboyu/`)
  - Embedding cache: `$XDG_CACHE_HOME/oboyu/embedding/cache/` (default: `~/.cache/oboyu/embedding/cache/`)
  - Embedding models: `$XDG_DATA_HOME/oboyu/embedding/models/` (default: `~/.local/share/oboyu/embedding/models/`)
- **Removed hardcoded paths** from `src/oboyu/indexer/embedding.py` and now import from central path definition
- **Updated documentation** in README.md to reference new XDG-compliant configuration path

### Breaking Changes:
- This change breaks backward compatibility with previous installations using `~/.oboyu/`
- No migration path is provided as this is targeting a single user installation

## Test plan
- [x] All existing tests pass
- [x] Code quality checks (ruff, mypy) pass
- [x] Verified paths are properly centralized and use XDG environment variables
- [x] Updated documentation reflects new path structure

🤖 Generated with [Claude Code](https://claude.ai/code)