### PR TITLE
fix: change search results from distance to similarity scores (#28)

### DIFF
--- a/src/oboyu/indexer/database.py
+++ b/src/oboyu/indexer/database.py
@@ -365,6 +365,12 @@ class Database:
         # Format results
         formatted_results = []
         for row in results:
+            # Convert cosine distance to similarity score
+            # Cosine distance ranges from 0 to 2, where 0 is best match
+            # Convert to similarity score where 1 is best match
+            distance = float(row[7])
+            similarity_score = 1.0 - (distance / 2.0)
+            
             formatted_results.append({
                 "chunk_id": row[0],
                 "path": row[1],
@@ -373,7 +379,7 @@ class Database:
                 "chunk_index": row[4],
                 "language": row[5],
                 "metadata": json.loads(row[6]) if row[6] else {},
-                "score": float(row[7]),  # Convert to float for JSON serialization
+                "score": similarity_score,  # Now higher scores are better
             })
 
         return formatted_results

--- a/src/oboyu/indexer/indexer.py
+++ b/src/oboyu/indexer/indexer.py
@@ -47,7 +47,7 @@ class SearchResult:
     """Additional metadata about the chunk."""
 
     score: float
-    """Similarity score (lower is better for cosine distance)."""
+    """Similarity score (0-1, where 1 is perfect match)."""
 
 
 class Indexer:

--- a/tests/indexer/test_database.py
+++ b/tests/indexer/test_database.py
@@ -142,7 +142,7 @@ class TestDatabase:
             results = db.search(vector, limit=1)
             assert len(results) == 1
             assert results[0]["chunk_id"] == "test-chunk-1"
-            assert results[0]["score"] < 0.0001  # Should be very close to 0 for exact match
+            assert results[0]["score"] > 0.999  # Should be very close to 1.0 for exact match
             
             # Close database connection
             db.close()

--- a/tests/indexer/test_search_ordering.py
+++ b/tests/indexer/test_search_ordering.py
@@ -1,0 +1,92 @@
+"""Test to verify search results are ordered correctly (descending by score)."""
+
+import tempfile
+from pathlib import Path
+import numpy as np
+import pytest
+from oboyu.indexer.database import Database
+from oboyu.indexer.processor import Chunk
+from datetime import datetime
+
+def test_search_results_descending_order():
+    """Test that search results are ordered in descending order by score."""
+    # Create a temporary database path
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        
+        # Initialize database
+        db = Database(db_path=db_path, embedding_dimensions=3)
+        db.setup()
+        
+        # Create test chunks
+        chunks = []
+        for i in range(5):
+            chunk = Chunk(
+                id=f"chunk_{i}",
+                path=Path(f"/test/doc_{i}.txt"),
+                title=f"Document {i}",
+                content=f"Test content for document {i}",
+                chunk_index=0,
+                language="en",
+                created_at=datetime.now(),
+                modified_at=datetime.now(),
+                metadata={}
+            )
+            chunks.append(chunk)
+        
+        # Store chunks
+        db.store_chunks(chunks)
+        
+        # Create embeddings with different vectors that will have different distances
+        # to our query vector
+        embeddings = []
+        vectors = [
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),  # Should be closest
+            np.array([0.8, 0.2, 0.0], dtype=np.float32),  # Second closest
+            np.array([0.5, 0.5, 0.0], dtype=np.float32),  # Third
+            np.array([0.2, 0.8, 0.0], dtype=np.float32),  # Fourth
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),  # Farthest
+        ]
+        
+        for i, vector in enumerate(vectors):
+            # Normalize the vector
+            vector = vector / np.linalg.norm(vector)
+            embeddings.append((
+                f"embedding_{i}",
+                f"chunk_{i}",
+                vector,
+                datetime.now()
+            ))
+        
+        # Store embeddings
+        db.store_embeddings(embeddings, "test_model")
+        
+        # Search with a query vector close to [1, 0, 0]
+        query_vector = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        query_vector = query_vector / np.linalg.norm(query_vector)
+        
+        # Search for top 3 results
+        results = db.search(query_vector, limit=3)
+        
+        # Verify results are ordered correctly (descending by score)
+        scores = [result['score'] for result in results]
+        
+        # Check that scores are in descending order (higher is better)
+        assert all(scores[i] >= scores[i+1] for i in range(len(scores)-1)), \
+            f"Results should be ordered in descending order by score, but got: {scores}"
+        
+        # Verify scores are in expected range (0-1)
+        assert all(0 <= score <= 1 for score in scores), \
+            f"Scores should be between 0 and 1, but got: {scores}"
+        
+        # Also verify that we got the expected documents
+        # With our similarity scores, higher values mean better matches
+        # The search function should return results with higher scores (better matches) first
+        expected_order = ["Document 0", "Document 1", "Document 2"]
+        actual_order = [result['title'] for result in results]
+        
+        assert actual_order == expected_order, \
+            f"Expected documents in order {expected_order}, but got {actual_order}"
+        
+        # Clean up
+        db.close()


### PR DESCRIPTION
## Summary
- Transform cosine distance scores to similarity scores for more intuitive search results
- Keep internal ORDER BY ASC for distance values but return similarity scores where higher = better

## Changes
- Modified `database.py` to convert cosine distance (0-2) to similarity scores (0-1) using formula: `similarity = 1.0 - (distance / 2.0)`
- Updated `SearchResult` docstring to reflect new scoring system (0-1, where 1 is perfect match)
- Fixed existing test that expected distance scores to now expect similarity scores
- Added new test `test_search_ordering.py` to verify correct ordering behavior

## Test plan
- [x] All existing tests pass
- [x] New test verifies search results are ordered correctly
- [x] Linting and type checking pass

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)