### PR TITLE
feat: add YAML front matter support for markdown files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "onnx>=1.18.0",
     "onnxruntime>=1.22.0",
     "optimum>=1.25.3",
+    "python-frontmatter>=1.1.0",
 ]
 
 [project.scripts]

--- a/src/oboyu/indexer/processor.py
+++ b/src/oboyu/indexer/processor.py
@@ -100,6 +100,22 @@ class DocumentProcessor:
 
         # Create chunk objects
         now = datetime.now()
+        
+        # Extract dates from metadata if available
+        created_at = now
+        modified_at = now
+        
+        if metadata:
+            if 'created_at' in metadata and isinstance(metadata['created_at'], datetime):
+                created_at = metadata['created_at']
+                # Remove from metadata dict to avoid duplication in JSON field
+                metadata = {k: v for k, v in metadata.items() if k != 'created_at'}
+            
+            if 'updated_at' in metadata and isinstance(metadata['updated_at'], datetime):
+                modified_at = metadata['updated_at']
+                # Remove from metadata dict to avoid duplication in JSON field
+                metadata = {k: v for k, v in metadata.items() if k != 'updated_at'}
+        
         result = []
 
         for i, chunk_text in enumerate(chunks):
@@ -114,8 +130,8 @@ class DocumentProcessor:
                 content=chunk_text,
                 chunk_index=i,
                 language=language,
-                created_at=now,
-                modified_at=now,
+                created_at=created_at,
+                modified_at=modified_at,
                 metadata=metadata or {},
             )
 

--- a/tests/crawler/test_crawler.py
+++ b/tests/crawler/test_crawler.py
@@ -93,14 +93,23 @@ class TestCrawler:
         """Test title generation from content and filename."""
         crawler = Crawler()
         
-        # Test title from content
+        # Test title from metadata
         path = Path("test.txt")
         content = "Title Line\nSecond line\nThird line"
-        title = crawler._generate_title(path, content)
+        metadata = {"title": "Metadata Title"}
+        title = crawler._generate_title(path, content, metadata)
+        assert title == "Metadata Title"
+        
+        # Test title from content when no metadata
+        path = Path("test.txt")
+        content = "Title Line\nSecond line\nThird line"
+        metadata = {}
+        title = crawler._generate_title(path, content, metadata)
         assert title == "Title Line"
         
         # Test title from filename when content doesn't have a good title
         path = Path("document-title.txt")
         content = "This is not a good title because it is too long and contains multiple sentences. It should not be used as a title."
-        title = crawler._generate_title(path, content)
+        metadata = {}
+        title = crawler._generate_title(path, content, metadata)
         assert title == "document-title"

--- a/tests/crawler/test_extractor.py
+++ b/tests/crawler/test_extractor.py
@@ -1,11 +1,12 @@
 """Tests for the content extraction functionality."""
 
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 import pytest
 
-from oboyu.crawler.extractor import extract_content, _detect_language, _extract_by_type
+from oboyu.crawler.extractor import extract_content, _detect_language, _extract_by_type, _parse_front_matter
 
 
 class TestExtractor:
@@ -19,11 +20,12 @@ class TestExtractor:
             Path(temp_file.name).write_text(test_content)
             
             # Extract content
-            content, language = extract_content(Path(temp_file.name))
+            content, language, metadata = extract_content(Path(temp_file.name))
             
             # Check results
             assert content == test_content
             assert language == "en"
+            assert metadata == {}  # No metadata for plain text
     
     def test_extract_content_with_japanese(self) -> None:
         """Test content extraction with Japanese text."""
@@ -33,11 +35,12 @@ class TestExtractor:
             Path(temp_file.name).write_text(test_content)
             
             # Extract content
-            content, language = extract_content(Path(temp_file.name))
+            content, language, metadata = extract_content(Path(temp_file.name))
             
             # Check results
             assert content == test_content
             assert language == "ja"
+            assert metadata == {}  # No metadata for plain text
     
     def test_extract_by_type(self) -> None:
         """Test extract_by_type function properly extracts text content."""
@@ -46,12 +49,14 @@ class TestExtractor:
             Path(temp_file.name).write_text(test_content)
             
             # Test with various file types
-            content = _extract_by_type(Path(temp_file.name), "text/plain")
+            content, metadata = _extract_by_type(Path(temp_file.name), "text/plain")
             assert content == test_content
+            assert metadata == {}
             
             # Non-text types should still be extracted as text in Oboyu
-            content = _extract_by_type(Path(temp_file.name), "application/pdf")
+            content, metadata = _extract_by_type(Path(temp_file.name), "application/pdf")
             assert content == test_content
+            assert metadata == {}
     
     def test_extract_content_missing_file(self) -> None:
         """Test extraction with a non-existent file."""
@@ -86,3 +91,136 @@ class TestLanguageDetection:
         text = "This text contains a lot of Japanese like これは日本語のテキストです。今日はいい天気ですね。"
         # Should detect as Japanese since it's more than 5%
         assert _detect_language(text) == "ja"
+
+
+class TestYamlFrontMatter:
+    """Test cases for YAML front matter parsing."""
+    
+    def test_parse_front_matter_basic(self) -> None:
+        """Test parsing basic YAML front matter."""
+        content = """---
+title: Test Document
+author: Test Author
+created_at: 2025-05-24T10:00:00Z
+updated_at: 2025-05-24T12:00:00Z
+uri: https://example.com/test
+---
+# Main Content
+
+This is the actual content of the document."""
+        
+        result_content, metadata = _parse_front_matter(content)
+        expected_content = """# Main Content
+
+This is the actual content of the document."""
+        assert result_content == expected_content
+        assert metadata['title'] == 'Test Document'
+        assert 'created_at' in metadata
+        assert 'updated_at' in metadata
+        assert metadata['uri'] == 'https://example.com/test'
+    
+    def test_parse_front_matter_with_only_title(self) -> None:
+        """Test parsing YAML front matter with only title."""
+        content = """---
+title: Test Document
+---
+Content here"""
+        
+        result_content, metadata = _parse_front_matter(content)
+        assert result_content == "Content here"
+        assert metadata == {'title': 'Test Document'}
+    
+    def test_no_yaml_front_matter(self) -> None:
+        """Test content without YAML front matter remains unchanged."""
+        content = """# Regular Markdown
+
+This document has no front matter."""
+        
+        result_content, metadata = _parse_front_matter(content)
+        assert result_content == content
+        assert metadata == {}
+    
+    def test_yaml_front_matter_only_at_start(self) -> None:
+        """Test that only YAML front matter at the start is parsed."""
+        content = """---
+title: Test
+---
+Some content
+
+---
+This should not be removed
+---
+More content"""
+        
+        result_content, metadata = _parse_front_matter(content)
+        expected = """Some content
+
+---
+This should not be removed
+---
+More content"""
+        assert result_content == expected
+        assert metadata == {'title': 'Test'}
+    
+    def test_extract_content_with_yaml_front_matter(self) -> None:
+        """Test full extraction pipeline with YAML front matter."""
+        with tempfile.NamedTemporaryFile(suffix=".md", mode='w', encoding='utf-8', delete=False) as temp_file:
+            # Write test content with YAML front matter
+            test_content = """---
+title: 日本語のドキュメント
+created_at: 2025-05-24T10:00:00Z
+updated_at: 2025-05-24T12:00:00Z
+uri: https://example.com/japanese
+author: テスト著者
+tags:
+  - japanese
+  - test
+---
+# 日本語のテスト
+
+これはYAMLフロントマターを含むテストファイルです。"""
+            
+            temp_file.write(test_content)
+            temp_file.flush()
+            
+            # Extract content
+            content, language, metadata = extract_content(Path(temp_file.name))
+            
+            # Check results - should have front matter removed
+            expected_content = """# 日本語のテスト
+
+これはYAMLフロントマターを含むテストファイルです。"""
+            assert content == expected_content
+            assert language == "ja"
+            assert metadata['title'] == '日本語のドキュメント'
+            assert 'created_at' in metadata
+            assert 'updated_at' in metadata
+            assert metadata['uri'] == 'https://example.com/japanese'
+            
+            # Clean up
+            Path(temp_file.name).unlink()
+    
+    def test_empty_yaml_front_matter(self) -> None:
+        """Test parsing empty YAML front matter."""
+        content = """---
+---
+# Content starts here"""
+        
+        result_content, metadata = _parse_front_matter(content)
+        assert result_content == "# Content starts here"
+        assert metadata == {}
+    
+    def test_parse_front_matter_datetime_types(self) -> None:
+        """Test parsing different datetime formats in front matter."""
+        content = """---
+title: Test with Dates
+created_at: 2025-05-24T10:00:00Z
+updated_at: 2025-05-24T12:00:00+09:00
+---
+Content here"""
+        
+        result_content, metadata = _parse_front_matter(content)
+        assert result_content == "Content here"
+        assert metadata['title'] == 'Test with Dates'
+        assert isinstance(metadata['created_at'], datetime)
+        assert isinstance(metadata['updated_at'], datetime)

--- a/uv.lock
+++ b/uv.lock
@@ -632,6 +632,7 @@ dependencies = [
     { name = "onnxruntime" },
     { name = "optimum" },
     { name = "protobuf" },
+    { name = "python-frontmatter" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sentence-transformers" },
@@ -663,6 +664,7 @@ requires-dist = [
     { name = "onnxruntime", specifier = ">=1.22.0" },
     { name = "optimum", specifier = ">=1.25.3" },
     { name = "protobuf", specifier = ">=4.25.1" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.4.2" },
     { name = "sentence-transformers" },
@@ -937,6 +939,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload_time = "2025-03-25T10:14:56.835Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload_time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload_time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload_time = "2024-01-16T18:50:00.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements proper YAML front matter parsing and metadata extraction for markdown files, replacing the initial implementation that only removed front matter.

Closes #27

## Changes
- Added `python-frontmatter` dependency for robust YAML parsing
- Parse and extract metadata fields from YAML front matter:
  - `title`: Used as document title (takes precedence over generated titles)
  - `created_at`: Used for chunk creation timestamp
  - `updated_at`: Used for chunk modification timestamp  
  - `uri`: Stored in metadata JSON field
  - Other fields are preserved in metadata
- Updated `extract_content()` to return tuple of `(content, language, metadata)`
- Modified crawler to use metadata title when available
- Updated processor to use metadata dates for chunk timestamps
- Added comprehensive test coverage for various YAML front matter formats

## Implementation Details
The implementation follows this flow:
1. **Extractor**: Parses YAML front matter using `python-frontmatter`, extracts supported fields
2. **Crawler**: Merges extracted metadata with existing metadata, uses metadata title if available
3. **Processor**: Uses metadata dates for chunk timestamps, stores other metadata in JSON field
4. **Database**: Stores title, created_at, updated_at as columns; uri and other fields in metadata JSON

## Test Plan
- [x] Added 7 new test cases for YAML front matter parsing
- [x] Updated existing tests to handle new function signatures
- [x] All 113 tests pass
- [x] Linting passes (ruff)
- [x] Type checking passes (mypy)

## Example Usage
Markdown file with YAML front matter:
```markdown
---
title: My Document Title
created_at: 2024-01-01T10:00:00Z
updated_at: 2024-01-15T15:30:00Z
uri: https://example.com/docs/my-document
tags: [python, documentation]
---
# Document Content

This content will be indexed without the YAML front matter,
but the metadata will be properly stored and searchable.
```

🤖 Generated with [Claude Code](https://claude.ai/code)