### PR TITLE
fix: use XDG cache directory for ONNX model storage (#37)

### DIFF
--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -92,6 +92,28 @@ indexer:
   embedding_device: cpu  # ONNX is most beneficial for CPU
 ```
 
+##### ONNX Model Cache Directory Structure
+
+ONNX models are cached following the XDG Base Directory specification:
+
+```
+$XDG_CACHE_HOME/oboyu/embedding/cache/     # ~/.cache/oboyu/embedding/cache/
+├── models/                                # ONNX converted models
+│   └── onnx/                              # ONNX model subdirectory
+│       ├── cl-nagoya_ruri-v3-30m/
+│       │   ├── model.onnx                 # Converted ONNX model
+│       │   ├── model_optimized.onnx       # Optimized ONNX model (if optimization succeeds)
+│       │   ├── tokenizer_config.json      # Tokenizer configuration
+│       │   ├── special_tokens_map.json    # Special tokens mapping
+│       │   ├── vocab.txt                  # Vocabulary file
+│       │   └── onnx_config.json           # ONNX-specific configuration
+│       └── other_model_name/
+│           └── ...
+└── [embedding cache files]                # Regular embedding cache (*.pkl files)
+```
+
+The ONNX models are stored in the cache directory because they can be regenerated from the original models, making them appropriate for cache storage according to XDG specifications.
+
 #### Lazy Loading
 
 The EmbeddingGenerator implements lazy loading for optimal performance:

--- a/src/oboyu/indexer/embedding.py
+++ b/src/oboyu/indexer/embedding.py
@@ -35,7 +35,7 @@ class EmbeddingCache:
         """Initialize the embedding cache.
 
         Args:
-            cache_dir: Directory to store cached embeddings (defaults to XDG config path)
+            cache_dir: Directory to store cached embeddings (defaults to XDG cache path)
 
         """
         self.cache_dir = Path(cache_dir)
@@ -126,8 +126,8 @@ class EmbeddingGenerator:
             max_seq_length: Maximum sequence length for the model
             query_prefix: Prefix to add to search queries
             use_cache: Whether to use embedding cache
-            cache_dir: Directory to store cached embeddings (defaults to XDG config path)
-            model_dir: Directory to store downloaded models (defaults to XDG config path)
+            cache_dir: Directory to store cached embeddings (defaults to XDG cache path)
+            model_dir: Directory to store downloaded models (defaults to XDG data path)
             use_onnx: Whether to use ONNX optimization for faster inference
 
         Note:

--- a/src/oboyu/indexer/embedding.py
+++ b/src/oboyu/indexer/embedding.py
@@ -176,7 +176,8 @@ class EmbeddingGenerator:
             model: Any  # Type hint to allow both model types
             if self.use_onnx:
                 # Load or convert to ONNX model
-                onnx_path = get_or_convert_onnx_model(self.model_name, self.model_dir)
+                # ONNX models are cached separately in XDG cache directory
+                onnx_path = get_or_convert_onnx_model(self.model_name)
                 model = ONNXEmbeddingModel(
                     onnx_path,
                     max_seq_length=self.max_seq_length,

--- a/src/oboyu/indexer/onnx_converter.py
+++ b/src/oboyu/indexer/onnx_converter.py
@@ -16,7 +16,7 @@ from onnxruntime import GraphOptimizationLevel, InferenceSession, SessionOptions
 from sentence_transformers import SentenceTransformer
 from transformers import AutoTokenizer  # type: ignore[attr-defined]
 
-from oboyu.common.paths import EMBEDDING_MODELS_DIR
+from oboyu.common.paths import EMBEDDING_CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -258,19 +258,22 @@ def convert_to_onnx(
 
 def get_or_convert_onnx_model(
     model_name: str,
-    cache_dir: Union[str, Path] = EMBEDDING_MODELS_DIR,
+    cache_dir: Optional[Union[str, Path]] = None,
 ) -> Path:
     """Get ONNX model path, converting if necessary.
 
     Args:
         model_name: Name of the SentenceTransformer model
-        cache_dir: Directory to cache ONNX models
+        cache_dir: Directory to cache ONNX models (defaults to XDG cache path)
 
     Returns:
         Path to ONNX model file
 
     """
-    cache_dir = Path(cache_dir)
+    if cache_dir is None:
+        cache_dir = EMBEDDING_CACHE_DIR / "models"
+    else:
+        cache_dir = Path(cache_dir)
     model_dir = cache_dir / "onnx" / model_name.replace("/", "_")
     
     # Try optimized model first


### PR DESCRIPTION
## Summary
- Changed ONNX model storage location from `EMBEDDING_MODELS_DIR` (XDG data directory) to `EMBEDDING_CACHE_DIR/models` (XDG cache directory)
- Updated `get_or_convert_onnx_model()` to use the XDG cache directory by default
- Added documentation showing the ONNX cache directory structure
- Fixed incorrect docstring comments about XDG paths

## Changes Made

### Code Changes
1. **`src/oboyu/indexer/onnx_converter.py`**:
   - Changed import from `EMBEDDING_MODELS_DIR` to `EMBEDDING_CACHE_DIR`
   - Updated `get_or_convert_onnx_model()` to default to `EMBEDDING_CACHE_DIR/models`
   - ONNX models now stored at: `$XDG_CACHE_HOME/oboyu/embedding/cache/models/onnx/<model_name>/`

2. **`src/oboyu/indexer/embedding.py`**:
   - Fixed docstring comments (cache_dir and model_dir descriptions)
   - Updated ONNX model loading to use default cache directory

### Documentation Changes
3. **`docs/indexer.md`**:
   - Added "ONNX Model Cache Directory Structure" section
   - Shows complete directory hierarchy for ONNX models in XDG cache

## Rationale
According to the XDG Base Directory specification:
- **Cache directory** (`$XDG_CACHE_HOME`): For data that can be regenerated
- **Data directory** (`$XDG_DATA_HOME`): For persistent user data

ONNX models are converted from source models and can be regenerated at any time, making them appropriate for cache storage rather than persistent data storage.

## Test plan
- [x] All existing tests pass
- [x] `test_onnx_converter.py` tests pass with new directory structure
- [x] `test_embedding.py` tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Pre-commit hooks pass

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)