### PR TITLE
fix: disable Rich formatting for CLI help output

### DIFF
--- a/src/oboyu/cli/index.py
+++ b/src/oboyu/cli/index.py
@@ -20,12 +20,14 @@ from oboyu.indexer.indexer import Indexer
 app = typer.Typer(
     help="Index documents for search and manage the index",
     pretty_exceptions_enable=False,
+    rich_markup_mode=None,
 )
 
 # Create manage subcommand app
 manage_app = typer.Typer(
     help="Manage the index database",
     pretty_exceptions_enable=False,
+    rich_markup_mode=None,
 )
 app.add_typer(manage_app, name="manage", help="Manage the index database")
 

--- a/src/oboyu/cli/main.py
+++ b/src/oboyu/cli/main.py
@@ -32,6 +32,8 @@ app = typer.Typer(
     name="oboyu",
     help="A Japanese-enhanced semantic search system for your local documents.",
     add_completion=False,
+    pretty_exceptions_enable=False,
+    rich_markup_mode=None,
     context_settings={
         "help_option_names": ["-h", "--help"],
     },

--- a/src/oboyu/cli/mcp.py
+++ b/src/oboyu/cli/mcp.py
@@ -18,6 +18,7 @@ from oboyu.mcp.context import db_path_global, mcp
 app = typer.Typer(
     help="Run an MCP server for semantic search",
     pretty_exceptions_enable=False,
+    rich_markup_mode=None,
 )
 
 # Create console for rich output

--- a/src/oboyu/cli/query.py
+++ b/src/oboyu/cli/query.py
@@ -21,6 +21,7 @@ from oboyu.indexer.indexer import Indexer, SearchResult
 app = typer.Typer(
     help="Search indexed documents",
     pretty_exceptions_enable=False,
+    rich_markup_mode=None,
 )
 
 # Create console for rich output


### PR DESCRIPTION
## Summary
- Disable Rich formatting for CLI help output by setting `rich_markup_mode=None` on all Typer instances
- Ensure consistent plain text help display across all commands

## Changes
- Add `rich_markup_mode=None` to all Typer app instances in:
  - `src/oboyu/cli/main.py`
  - `src/oboyu/cli/query.py`
  - `src/oboyu/cli/index.py` (both main app and manage_app)
  - `src/oboyu/cli/mcp.py`
- Add missing `pretty_exceptions_enable=False` to main.py

## Test plan
- [x] Run `oboyu --help` and verify plain text output
- [x] Run `oboyu index --help` and verify plain text output
- [x] Run `oboyu query --help` and verify plain text output
- [x] All tests pass
- [x] Linting and type checking pass

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)