### PR TITLE
fix: disable tokenizer parallelism warning in interactive mode

### DIFF
--- a/src/oboyu/cli/query.py
+++ b/src/oboyu/cli/query.py
@@ -4,6 +4,7 @@ This module provides the command-line interface for querying indexed documents.
 """
 
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -17,6 +18,9 @@ from prompt_toolkit.history import FileHistory
 from rich.console import Console
 from rich.text import Text
 from typing_extensions import Annotated
+
+# Disable tokenizer parallelism to avoid forking warnings
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from oboyu.cli.hierarchical_logger import create_hierarchical_logger
 from oboyu.common.paths import DEFAULT_DB_PATH


### PR DESCRIPTION
## Summary
- Set `TOKENIZERS_PARALLELISM=false` environment variable to prevent HuggingFace tokenizers warning
- Warning was appearing when using interactive mode: "The current process just got forked, after parallelism has already been used"

## Test plan
- [x] Run `oboyu query --interactive` and verify no tokenizer warning appears
- [x] Verify search functionality still works correctly in interactive mode

🤖 Generated with [Claude Code](https://claude.ai/code)