### PR TITLE
Remove configurable follow_symlinks and max_file_size options from crawler configuration

### DIFF
--- a/docs/crawler.md
+++ b/docs/crawler.md
@@ -31,11 +31,11 @@ def discover_documents(
     patterns: List[str],
     exclude_patterns: List[str],
     max_depth: int = 10,
-    follow_symlinks: bool = False,
     respect_gitignore: bool = True
 ) -> List[Tuple[Path, Dict[str, Any]]]:
     """Discover documents matching patterns with metadata."""
     # Returns list of (path, metadata) tuples
+    # Note: max_file_size is hard-coded to 10MB, follow_symlinks is hard-coded to False
 ```
 
 ### Content Extraction
@@ -120,11 +120,13 @@ crawler:
   exclude_patterns:              # Patterns to exclude
     - "*/node_modules/*"
     - "*/venv/*"
-  max_file_size: 10485760        # 10MB maximum file size
-  follow_symlinks: false         # Whether to follow symbolic links
   respect_gitignore: true        # Whether to respect .gitignore files
   # Japanese encoding detection is automatic
   max_workers: 4                 # Number of parallel workers for processing
+  
+  # Hard-coded values (no longer configurable):
+  # max_file_size: 10MB          # Maximum file size
+  # follow_symlinks: false       # Never follow symbolic links
 ```
 
 ## Performance Considerations

--- a/src/oboyu/cli/index.py
+++ b/src/oboyu/cli/index.py
@@ -142,7 +142,6 @@ def status(
                 patterns=crawler_config.include_patterns,
                 exclude_patterns=crawler_config.exclude_patterns,
                 max_depth=crawler_config.depth,
-                follow_symlinks=crawler_config.follow_symlinks,
             )
 
             # Detect changes (extract just paths from tuples)
@@ -265,7 +264,6 @@ def diff(
                 patterns=crawler_config.include_patterns,
                 exclude_patterns=crawler_config.exclude_patterns,
                 max_depth=crawler_config.depth,
-                follow_symlinks=crawler_config.follow_symlinks,
             )
 
             # Detect changes (extract just paths from tuples)
@@ -529,7 +527,6 @@ def index(
                 depth=max_depth or 10,
                 include_patterns=include_patterns or ["*.txt", "*.md", "*.html", "*.py", "*.java"],
                 exclude_patterns=exclude_patterns or ["*/node_modules/*", "*/venv/*"],
-                follow_symlinks=False,
                 max_workers=4,
                 respect_gitignore=True,
             )

--- a/src/oboyu/crawler/config.py
+++ b/src/oboyu/crawler/config.py
@@ -21,8 +21,6 @@ DEFAULT_CONFIG = {
             "*/node_modules/*",
             "*/.venv/*",
         ],
-        "max_file_size": 10 * 1024 * 1024,  # 10MB
-        "follow_symlinks": False,
         "max_workers": 4,  # Default number of worker threads
         "respect_gitignore": True,  # Whether to respect .gitignore files
     }
@@ -32,10 +30,12 @@ DEFAULT_CONFIG = {
 DEFAULT_DEPTH = 10
 DEFAULT_INCLUDE_PATTERNS = ["*.txt", "*.md", "*.html", "*.py", "*.java"]
 DEFAULT_EXCLUDE_PATTERNS = ["*/node_modules/*", "*/venv/*"]
-DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
-DEFAULT_FOLLOW_SYMLINKS = False
 DEFAULT_MAX_WORKERS = 4
 DEFAULT_RESPECT_GITIGNORE = True
+
+# Hard-coded values (no longer configurable)
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+FOLLOW_SYMLINKS = False
 
 
 class CrawlerConfig:
@@ -115,13 +115,6 @@ class CrawlerConfig:
         if not isinstance(exclude_patterns, list) or exclude_patterns is None:
             crawler_config["exclude_patterns"] = DEFAULT_EXCLUDE_PATTERNS[:]
 
-        # Validate max_file_size - must be a positive integer
-        if not isinstance(crawler_config.get("max_file_size"), int) or crawler_config.get("max_file_size", 0) <= 0:
-            crawler_config["max_file_size"] = DEFAULT_MAX_FILE_SIZE
-
-        # Validate follow_symlinks - must be a boolean
-        if not isinstance(crawler_config.get("follow_symlinks"), bool):
-            crawler_config["follow_symlinks"] = DEFAULT_FOLLOW_SYMLINKS
 
         # Validate max_workers - must be a positive integer
         if not isinstance(crawler_config.get("max_workers"), int) or crawler_config.get("max_workers", 0) <= 0:
@@ -146,15 +139,6 @@ class CrawlerConfig:
         """Patterns to exclude."""
         return list(self.config["crawler"]["exclude_patterns"])
 
-    @property
-    def max_file_size(self) -> int:
-        """Maximum file size in bytes."""
-        return int(self.config["crawler"]["max_file_size"])
-
-    @property
-    def follow_symlinks(self) -> bool:
-        """Whether to follow symbolic links."""
-        return bool(self.config["crawler"]["follow_symlinks"])
 
     @property
     def max_workers(self) -> int:

--- a/src/oboyu/crawler/crawler.py
+++ b/src/oboyu/crawler/crawler.py
@@ -41,8 +41,6 @@ class Crawler:
         depth: int = 10,
         include_patterns: Optional[List[str]] = None,
         exclude_patterns: Optional[List[str]] = None,
-        max_file_size: int = 10 * 1024 * 1024,  # 10MB
-        follow_symlinks: bool = False,
         max_workers: int = 4,  # Number of worker threads for parallel processing
         respect_gitignore: bool = True,  # Whether to respect .gitignore files
     ) -> None:
@@ -52,17 +50,17 @@ class Crawler:
             depth: Maximum directory traversal depth
             include_patterns: File patterns to include (e.g., "*.txt", "*.md")
             exclude_patterns: Patterns to exclude (e.g., "*/node_modules/*")
-            max_file_size: Maximum file size in bytes to process
-            follow_symlinks: Whether to follow symbolic links during traversal
             max_workers: Maximum number of worker threads for parallel processing
             respect_gitignore: Whether to respect .gitignore files (default: True)
+
+        Note:
+            max_file_size is hard-coded to 10MB and follow_symlinks is hard-coded to False
+            for consistency and security reasons.
 
         """
         self.depth = depth
         self.include_patterns = include_patterns or ["*.txt", "*.md", "*.html", "*.py", "*.java"]
         self.exclude_patterns = exclude_patterns or ["*/node_modules/*", "*/venv/*"]
-        self.max_file_size = max_file_size
-        self.follow_symlinks = follow_symlinks
         self.max_workers = max_workers
         self.respect_gitignore = respect_gitignore
 
@@ -86,8 +84,6 @@ class Crawler:
             patterns=self.include_patterns,
             exclude_patterns=self.exclude_patterns,
             max_depth=self.depth,
-            max_file_size=self.max_file_size,
-            follow_symlinks=self.follow_symlinks,
             respect_gitignore=self.respect_gitignore,
         )
 

--- a/tests/crawler/test_config.py
+++ b/tests/crawler/test_config.py
@@ -12,8 +12,6 @@ class TestCrawlerConfig:
         assert config.depth == 10
         assert "*.txt" in config.include_patterns
         assert "*/node_modules/*" in config.exclude_patterns
-        assert config.max_file_size == 10 * 1024 * 1024  # 10MB
-        assert not config.follow_symlinks
         assert config.max_workers == 4  # Default worker count
     
     def test_config_from_dict(self) -> None:
@@ -23,8 +21,6 @@ class TestCrawlerConfig:
                 "depth": 5,
                 "include_patterns": ["*.csv"],
                 "exclude_patterns": ["*/temp/*"],
-                "max_file_size": 1024,
-                "follow_symlinks": True,
                 "max_workers": 8,
             }
         }
@@ -33,8 +29,6 @@ class TestCrawlerConfig:
         assert config.depth == 5
         assert config.include_patterns == ["*.csv"]
         assert config.exclude_patterns == ["*/temp/*"]
-        assert config.max_file_size == 1024
-        assert config.follow_symlinks
         assert config.max_workers == 8
     
     def test_config_validation(self) -> None:
@@ -45,8 +39,6 @@ class TestCrawlerConfig:
                 "depth": -5,  # Invalid: negative - will be replaced with default
                 "include_patterns": "not-a-list",  # Invalid: not a list - will be replaced
                 "exclude_patterns": None,  # Invalid: None - will be replaced
-                "max_file_size": "1024",  # Invalid: string instead of int - will be replaced
-                "follow_symlinks": "true",  # Invalid: string instead of bool - will be replaced
                 "japanese_encodings": {},  # Invalid: dict instead of list - will be replaced
             }
         }
@@ -56,8 +48,6 @@ class TestCrawlerConfig:
         assert config.depth == 10  # Default
         assert "*.txt" in config.include_patterns  # Default include pattern
         assert "*/node_modules/*" in config.exclude_patterns  # Default exclude pattern
-        assert config.max_file_size == 10 * 1024 * 1024  # Default (10MB)
-        assert not config.follow_symlinks  # Default (False)
     
     def test_partial_config(self) -> None:
         """Test partial configuration override."""
@@ -79,5 +69,3 @@ class TestCrawlerConfig:
         # The validation should have added these fields with default values
         assert len(config.exclude_patterns) > 0
         assert "*/node_modules/*" in config.exclude_patterns
-        assert config.max_file_size == 10 * 1024 * 1024
-        assert isinstance(config.follow_symlinks, bool)

--- a/tests/crawler/test_crawler.py
+++ b/tests/crawler/test_crawler.py
@@ -18,8 +18,6 @@ class TestCrawler:
         assert crawler.depth == 10
         assert "*.txt" in crawler.include_patterns
         assert "*/node_modules/*" in crawler.exclude_patterns
-        assert crawler.max_file_size == 10 * 1024 * 1024  # 10MB
-        assert not crawler.follow_symlinks
         assert crawler.max_workers == 4  # Default worker count
         
         # Test with custom parameters
@@ -27,15 +25,11 @@ class TestCrawler:
             depth=5,
             include_patterns=["*.csv"],
             exclude_patterns=["*/temp/*"],
-            max_file_size=1024,
-            follow_symlinks=True,
             max_workers=8,
         )
         assert crawler.depth == 5
         assert crawler.include_patterns == ["*.csv"]
         assert crawler.exclude_patterns == ["*/temp/*"]
-        assert crawler.max_file_size == 1024
-        assert crawler.follow_symlinks
         assert crawler.max_workers == 8
     
     def test_crawler_crawl(self) -> None:

--- a/tests/crawler/test_discovery.py
+++ b/tests/crawler/test_discovery.py
@@ -111,29 +111,17 @@ class TestDiscovery:
             large_file = test_dir / "large.txt"
             large_file.write_text("Large file" * 50)  # ~500 bytes
             
-            # Discover documents with max_file_size=100
+            # Test is no longer valid since max_file_size is hard-coded
+            
+            # With hard-coded max_file_size=10MB, both files should be included
             documents = discover_documents(
                 directory=test_dir,
                 patterns=["*.txt"],
                 exclude_patterns=[],
                 max_depth=5,
-                max_file_size=100,
             )
             
-            # Should only include small file
-            assert len(documents) == 1
-            assert str(documents[0][0]) == str(small_file)
-            
-            # Discover documents with larger max_file_size
-            documents = discover_documents(
-                directory=test_dir,
-                patterns=["*.txt"],
-                exclude_patterns=[],
-                max_depth=5,
-                max_file_size=1000,  # Large enough for both files
-            )
-            
-            # Should include both files
+            # Should include both files (since 10MB > 500 bytes)
             assert len(documents) == 2
             paths = [str(doc[0]) for doc in documents]
             assert str(small_file) in paths


### PR DESCRIPTION
## Summary
- Remove configurable `follow_symlinks` and `max_file_size` options from crawler configuration
- Hard-code `follow_symlinks` to `false` and `max_file_size` to 10MB for security and consistency

## Test plan
- [x] All existing tests pass with updated expectations
- [x] Type checking passes with updated function signatures  
- [x] Linting passes without issues
- [x] Updated documentation reflects the changes

🤖 Generated with [Claude Code](https://claude.ai/code)