### PR TITLE
feat: remove dangerous clear_index tool from MCP server for improved safety

### DIFF
--- a/src/oboyu/mcp/__init__.py
+++ b/src/oboyu/mcp/__init__.py
@@ -5,6 +5,6 @@ allowing AI assistants to interact with Oboyu's Japanese-enhanced semantic searc
 """
 
 from oboyu.mcp.context import db_path_global, mcp
-from oboyu.mcp.server import clear_index, get_index_info, get_indexer, index_directory, search
+from oboyu.mcp.server import get_index_info, get_indexer, index_directory, search
 
-__all__ = ["context", "server", "mcp", "db_path_global", "get_indexer", "search", "get_index_info", "index_directory", "clear_index"]
+__all__ = ["context", "server", "mcp", "db_path_global", "get_indexer", "search", "get_index_info", "index_directory"]

--- a/src/oboyu/mcp/server.py
+++ b/src/oboyu/mcp/server.py
@@ -141,31 +141,6 @@ def index_directory(
         return {"error": str(e), "success": False, "documents_indexed": 0, "chunks_indexed": 0}
 
 
-@mcp.tool()
-def clear_index(
-    db_path: Optional[str] = None,
-) -> Dict[str, object]:
-    """Clear all data from the index database.
-
-    Args:
-        db_path: Optional path to the database file
-
-    Returns:
-        Dictionary containing operation results
-
-    """
-    try:
-        # Initialize indexer
-        indexer = get_indexer(db_path)
-
-        # Clear the index
-        indexer.clear_index()
-
-        # Return success
-        return {"success": True, "message": "Index database cleared successfully", "db_path": indexer.config.db_path}
-    except Exception as e:
-        logger.error(f"Error clearing index: {str(e)}")
-        return {"error": str(e), "success": False}
 
 
 @mcp.tool()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from oboyu.mcp.context import mcp
-from oboyu.mcp.server import get_indexer, search, get_index_info, index_directory, clear_index
+from oboyu.mcp.server import get_indexer, search, get_index_info, index_directory
 
 
 @pytest.fixture
@@ -137,39 +137,6 @@ def test_index_directory(mock_get_indexer, mock_indexer):
     mock_get_indexer.assert_not_called()
 
 
-@patch("oboyu.mcp.server.get_indexer")
-def test_clear_index(mock_get_indexer, mock_indexer):
-    """Test the clear_index tool function."""
-    # Setup the mock
-    mock_get_indexer.return_value = mock_indexer
-    mock_indexer.config.db_path = "/path/to/test.db"
-    
-    # Call the function
-    result = clear_index()
-    
-    # Verify the indexer was called
-    mock_get_indexer.assert_called_once_with(None)
-    mock_indexer.clear_index.assert_called_once()
-    
-    # Check the response format
-    assert "success" in result
-    assert result["success"] is True
-    assert "message" in result
-    assert "cleared successfully" in result["message"]
-    assert "db_path" in result
-    assert result["db_path"] == "/path/to/test.db"
-    
-    # Test error case
-    mock_get_indexer.reset_mock()
-    mock_indexer.clear_index.side_effect = Exception("Test error")
-    mock_get_indexer.return_value = mock_indexer
-    
-    result = clear_index()
-    
-    assert "success" in result
-    assert result["success"] is False
-    assert "error" in result
-    assert result["error"] == "Test error"
 
 
 @patch("oboyu.mcp.server.get_indexer")


### PR DESCRIPTION
## Summary
- Remove `clear_index` MCP tool to prevent accidental data loss from AI assistants and external integrations
- Preserve CLI clear functionality (`oboyu clear`) with proper confirmation prompts and safety mechanisms
- Improve MCP server safety by focusing on read/search operations only

## Problem Addressed
Resolves issue #104 - The `clear_index` tool in the MCP server posed significant safety risks:
- **No confirmation prompts** when called via MCP protocol
- **Accessible to AI assistants** which may call it unintentionally  
- **Cannot be undone** - all indexed documents and embeddings permanently lost
- **No safety mechanisms** or warnings in the MCP context

## Changes Made
- **Removed `clear_index` tool** from MCP server (`src/oboyu/mcp/server.py`)
- **Updated imports** in MCP module to remove clear_index references
- **Removed test cases** for clear_index functionality in MCP tests
- **Verified CLI functionality** - `oboyu clear` command still works with proper safeguards

## Benefits
- **Eliminates accidental data loss** from MCP integrations
- **Better separation of concerns** - administrative functions remain in CLI
- **Improved AI safety** - AI assistants cannot accidentally destroy user data
- **Maintains functionality** - users can still clear index via CLI with proper confirmation

## Test Results
- All MCP tests pass (5/5)
- All fast tests pass (244/245, 1 skipped)
- No regressions detected
- CLI clear command verified working

🤖 Generated with [Claude Code](https://claude.ai/code)