### PR TITLE
fix: ensure --rerank CLI flag properly initializes reranker service

### DIFF
--- a/src/oboyu/cli/services/query_service.py
+++ b/src/oboyu/cli/services/query_service.py
@@ -77,8 +77,18 @@ class QueryService:
         # Determine database path
         database_path = Path(db_path or query_config.get("database_path") or DEFAULT_DB_PATH)
         
-        # Initialize indexer with database path (simpler approach for query service)
-        indexer = Indexer.from_path(database_path)
+        # Initialize indexer with proper configuration including reranker settings
+        from oboyu.indexer.config.indexer_config import IndexerConfig
+        
+        config = IndexerConfig()
+        config.db_path = database_path
+        
+        # Apply reranker configuration if enabled
+        if query_config.get("use_reranker", False):
+            config.search.use_reranker = True
+            config.model.use_reranker = True
+        
+        indexer = Indexer(config)
         
         try:
             start_time = time.time()


### PR DESCRIPTION
## Summary
• Fixed QueryService to properly initialize IndexerConfig with reranker settings when --rerank flag is used
• Previously, the service used Indexer.from_path() which created default config with use_reranker=False, causing reranker service to never be initialized

## Test plan
- [x] Test `uv run oboyu query --rerank --query "ガジェット"` - now works with ~3s execution time (model loading) and reranked results
- [x] Test `uv run oboyu query --no-rerank --query "ガジェット"` - fast execution (~0.1s) with original ranking
- [x] Verify ranking changes: "ガジェット" document moved from position 4 to position 3 with reranking enabled

🎯 Generated with [Claude Code](https://claude.ai/code)