### PR TITLE
Remove GPU support completely and enforce CPU-only at API level

### DIFF
--- a/bench/reranker/benchmark_reranking.py
+++ b/bench/reranker/benchmark_reranking.py
@@ -28,7 +28,6 @@ class OboyuRerankerAdapter:
         self,
         model_name: str = "cl-nagoya/ruri-v3-reranker-310m",
         use_onnx: bool = True,
-        device: str = "cpu",
         batch_size: int = 8,
     ) -> None:
         """Initialize the Oboyu reranker adapter.
@@ -36,14 +35,12 @@ class OboyuRerankerAdapter:
         Args:
             model_name: Reranker model name
             use_onnx: Whether to use ONNX optimization
-            device: Device to run on (CPU only)
             batch_size: Batch size for reranking
         
         """
         self.reranker = create_reranker(
             model_name=model_name,
             use_onnx=use_onnx,
-            device="cpu",  # Fixed to CPU only
             batch_size=batch_size,
         )
         self.model_name = model_name
@@ -193,7 +190,6 @@ def benchmark_reranking_performance(
         reranker = OboyuRerankerAdapter(
             model_name=config.get("model_name", "cl-nagoya/ruri-v3-reranker-310m"),
             use_onnx=config.get("use_onnx", True),
-            device=config.get("device", "cpu"),
             batch_size=config.get("batch_size", 8),
         )
         
@@ -336,14 +332,12 @@ def main():
                 "name": "ruri-v3-reranker-310m-onnx",
                 "model_name": "cl-nagoya/ruri-v3-reranker-310m",
                 "use_onnx": True,
-                "device": "cpu",
                 "batch_size": 8,
             },
             {
                 "name": "ruri-v3-reranker-310m-pytorch",
                 "model_name": "cl-nagoya/ruri-v3-reranker-310m",
                 "use_onnx": False,
-                "device": "cpu",
                 "batch_size": 8,
             },
         ]

--- a/src/oboyu/common/config_schema.py
+++ b/src/oboyu/common/config_schema.py
@@ -66,15 +66,13 @@ class CrawlerConfigSchema(BaseModel):
 
 class IndexerConfigSchema(BaseModel):
     """Schema for indexer configuration."""
+    
+    model_config = {"extra": "forbid"}
 
     embedding_model: str = Field(
         default="cl-nagoya/ruri-v3-30m",
         description="Name or path of embedding model",
         pattern=r'^[\w\-./]+[\w\-/]+$'
-    )
-    embedding_device: Optional[Literal["cpu"]] = Field(
-        default="cpu",
-        description="Device for embedding generation (CPU only)"
     )
     batch_size: int = Field(default=128, ge=1, le=1024, description="Batch size for processing")
     max_length: int = Field(default=8192, ge=256, le=32768, description="Maximum sequence length")
@@ -95,15 +93,6 @@ class IndexerConfigSchema(BaseModel):
         # Be more lenient for testing - allow any non-empty string
         return v
 
-    @field_validator('embedding_device')
-    @classmethod
-    def validate_device(cls, v: Optional[str]) -> Optional[str]:
-        """Validate device is CPU (GPU support removed)."""
-        if v is not None and v != 'cpu':
-            import warnings
-            warnings.warn(f'Invalid device {v}, only CPU is supported. Falling back to CPU')
-            return 'cpu'
-        return v
 
     @field_validator('db_path')
     @classmethod

--- a/src/oboyu/common/model_manager.py
+++ b/src/oboyu/common/model_manager.py
@@ -30,7 +30,6 @@ class ModelManager(ABC):
         self,
         model_name: str,
         model_type: str,
-        device: str = "cpu",
         use_onnx: bool = True,
         cache_dir: Optional[Union[str, Path]] = None,
         **kwargs: Any,  # noqa: ANN401
@@ -40,7 +39,6 @@ class ModelManager(ABC):
         Args:
             model_name: Name of the model to load
             model_type: Type of model (embedding, reranker)
-            device: Device to run the model on (CPU only)
             use_onnx: Whether to use ONNX optimization
             cache_dir: Directory to cache models (defaults to XDG cache path)
             **kwargs: Additional model-specific configuration
@@ -48,8 +46,8 @@ class ModelManager(ABC):
         """
         self.model_name = model_name
         self.model_type = model_type
-        self.device = "cpu"  # Fixed to CPU only
-        self.use_onnx = use_onnx  # ONNX always available on CPU
+        self.device = "cpu"  # Always CPU-only
+        self.use_onnx = use_onnx
         self.cache_dir = Path(cache_dir) if cache_dir else EMBEDDING_CACHE_DIR / "models"
         self.config = kwargs
 
@@ -259,7 +257,6 @@ class EmbeddingModelManager(ModelManager):
     def __init__(
         self,
         model_name: str = "cl-nagoya/ruri-v3-30m",
-        device: str = "cpu",
         use_onnx: bool = True,
         max_seq_length: int = 8192,
         cache_dir: Optional[Union[str, Path]] = None,
@@ -271,7 +268,6 @@ class EmbeddingModelManager(ModelManager):
 
         Args:
             model_name: Name of the embedding model
-            device: Device to run the model on
             use_onnx: Whether to use ONNX optimization
             max_seq_length: Maximum sequence length
             cache_dir: Directory to cache models
@@ -283,7 +279,6 @@ class EmbeddingModelManager(ModelManager):
         super().__init__(
             model_name=model_name,
             model_type="embedding",
-            device=device,
             use_onnx=use_onnx,
             cache_dir=cache_dir,
             max_seq_length=max_seq_length,
@@ -371,7 +366,6 @@ class RerankerModelManager(ModelManager):
     def __init__(
         self,
         model_name: str = "cl-nagoya/ruri-reranker-small",
-        device: str = "cpu",
         use_onnx: bool = True,
         max_length: int = 512,
         cache_dir: Optional[Union[str, Path]] = None,
@@ -383,7 +377,6 @@ class RerankerModelManager(ModelManager):
 
         Args:
             model_name: Name of the reranker model
-            device: Device to run the model on
             use_onnx: Whether to use ONNX optimization
             max_length: Maximum sequence length
             cache_dir: Directory to cache models
@@ -395,7 +388,6 @@ class RerankerModelManager(ModelManager):
         super().__init__(
             model_name=model_name,
             model_type="reranker",
-            device=device,
             use_onnx=use_onnx,
             cache_dir=cache_dir,
             max_length=max_length,
@@ -471,7 +463,6 @@ class RerankerModelManager(ModelManager):
 def create_model_manager(
     model_type: str,
     model_name: str,
-    device: str = "cpu",
     use_onnx: bool = True,
     cache_dir: Optional[Union[str, Path]] = None,
     **kwargs: Any,  # noqa: ANN401
@@ -481,7 +472,6 @@ def create_model_manager(
     Args:
         model_type: Type of model (embedding, reranker)
         model_name: Name of the model
-        device: Device to run the model on
         use_onnx: Whether to use ONNX optimization
         cache_dir: Directory to cache models
         **kwargs: Additional model-specific configuration
@@ -496,7 +486,6 @@ def create_model_manager(
     if model_type == "embedding":
         return EmbeddingModelManager(
             model_name=model_name,
-            device=device,
             use_onnx=use_onnx,
             cache_dir=cache_dir,
             **kwargs,
@@ -504,7 +493,6 @@ def create_model_manager(
     elif model_type == "reranker":
         return RerankerModelManager(
             model_name=model_name,
-            device=device,
             use_onnx=use_onnx,
             cache_dir=cache_dir,
             **kwargs,

--- a/src/oboyu/config/schema.py
+++ b/src/oboyu/config/schema.py
@@ -66,15 +66,13 @@ class CrawlerConfigSchema(BaseModel):
 
 class IndexerConfigSchema(BaseModel):
     """Schema for indexer configuration."""
+    
+    model_config = {"extra": "forbid"}
 
     embedding_model: str = Field(
         default="cl-nagoya/ruri-v3-30m",
         description="Name or path of embedding model",
         pattern=r'^[\w\-./]+[\w\-/]+$'
-    )
-    embedding_device: Optional[Literal["cpu"]] = Field(
-        default="cpu",
-        description="Device for embedding generation (CPU only)"
     )
     batch_size: int = Field(default=128, ge=1, le=1024, description="Batch size for processing")
     max_length: int = Field(default=8192, ge=256, le=32768, description="Maximum sequence length")
@@ -95,15 +93,6 @@ class IndexerConfigSchema(BaseModel):
         # Be more lenient for testing - allow any non-empty string
         return v
 
-    @field_validator('embedding_device')
-    @classmethod
-    def validate_device(cls, v: Optional[str]) -> Optional[str]:
-        """Validate device is CPU (GPU support removed)."""
-        if v is not None and v != 'cpu':
-            import warnings
-            warnings.warn(f'Invalid device {v}, only CPU is supported. Falling back to CPU')
-            return 'cpu'
-        return v
 
     @field_validator('db_path')
     @classmethod

--- a/src/oboyu/indexer/config/model_config.py
+++ b/src/oboyu/indexer/config/model_config.py
@@ -10,7 +10,6 @@ class ModelConfig:
 
     # Embedding model settings
     embedding_model: str = "cl-nagoya/ruri-v3-30m"
-    embedding_device: str = "cpu"  # Fixed to CPU only
     batch_size: int = 64
     max_seq_length: int = 8192
     use_onnx: bool = True
@@ -29,7 +28,6 @@ class ModelConfig:
     reranker_model: str = "cl-nagoya/ruri-reranker-small"
     use_reranker: bool = False
     reranker_use_onnx: bool = False
-    reranker_device: str = "cpu"  # Fixed to CPU only
     reranker_batch_size: int = 16
     reranker_max_length: int = 512
 

--- a/src/oboyu/indexer/services/embedding.py
+++ b/src/oboyu/indexer/services/embedding.py
@@ -94,7 +94,6 @@ class EmbeddingService:
     def __init__(
         self,
         model_name: str = "cl-nagoya/ruri-v3-30m",
-        device: str = "cpu",
         batch_size: int = 64,
         max_seq_length: int = 8192,
         query_prefix: str = "検索クエリ: ",
@@ -107,7 +106,6 @@ class EmbeddingService:
 
         Args:
             model_name: Name of the embedding model
-            device: Device to run model on (CPU only)
             batch_size: Batch size for embedding generation
             max_seq_length: Maximum sequence length
             query_prefix: Prefix for search queries
@@ -118,7 +116,6 @@ class EmbeddingService:
 
         """
         self.model_name = model_name
-        self.device = device
         self.batch_size = batch_size
         self.max_seq_length = max_seq_length
         self.query_prefix = query_prefix
@@ -130,7 +127,6 @@ class EmbeddingService:
             self.model_manager = EmbeddingModelManager(
                 model_name=model_name,
                 models_dir=EMBEDDING_MODELS_DIR,
-                device=device,
                 max_seq_length=max_seq_length,
                 use_onnx=use_onnx,
                 quantization_config=onnx_quantization_config,

--- a/src/oboyu/retriever/services/reranker.py
+++ b/src/oboyu/retriever/services/reranker.py
@@ -37,13 +37,11 @@ class BaseReranker:
     def __init__(
         self,
         model_name: str = "cl-nagoya/ruri-reranker-small",
-        device: str = "cpu",
         batch_size: int = 8,
         max_length: int = 512,
     ) -> None:
         """Initialize the base reranker."""
         self.model_name = model_name
-        self.device = device
         self.batch_size = batch_size
         self.max_length = max_length
         self._model: Optional[Any] = None
@@ -65,19 +63,17 @@ class CrossEncoderReranker(BaseReranker):
     def __init__(
         self,
         model_name: str = "cl-nagoya/ruri-reranker-small",
-        device: str = "cpu",
         batch_size: int = 8,
         max_length: int = 512,
     ) -> None:
         """Initialize the CrossEncoder reranker with lazy loading."""
-        super().__init__(model_name, device, batch_size, max_length)
+        super().__init__(model_name, batch_size, max_length)
         logger.debug(f"Initializing CrossEncoder reranker with model: {model_name}")
 
         # Create model manager for unified model loading
         try:
             self.model_manager = RerankerModelManager(
                 model_name=model_name,
-                device=device,
                 use_onnx=False,  # This is the PyTorch version
                 max_length=max_length,
             )
@@ -172,7 +168,6 @@ class ONNXCrossEncoderReranker(BaseReranker):
     def __init__(
         self,
         model_name: str = "cl-nagoya/ruri-reranker-small",
-        device: str = "cpu",
         batch_size: int = 8,
         max_length: int = 512,
         cache_dir: Optional[Path] = None,
@@ -180,14 +175,13 @@ class ONNXCrossEncoderReranker(BaseReranker):
         optimization_level: str = "none",
     ) -> None:
         """Initialize the ONNX CrossEncoder reranker with lazy loading."""
-        super().__init__(model_name, device, batch_size, max_length)
+        super().__init__(model_name, batch_size, max_length)
         logger.debug(f"Initializing ONNX CrossEncoder reranker with model: {model_name}")
 
         # Create model manager for unified model loading
         try:
             self.model_manager = RerankerModelManager(
                 model_name=model_name,
-                device=device,
                 use_onnx=True,
                 max_length=max_length,
                 cache_dir=cache_dir,
@@ -267,7 +261,6 @@ class RerankerService:
         self,
         model_name: str = "cl-nagoya/ruri-reranker-small",
         use_onnx: bool = False,
-        device: str = "cpu",
         batch_size: int = 16,
         max_length: int = 512,
         quantization_config: Optional[Dict[str, Any]] = None,
@@ -277,7 +270,6 @@ class RerankerService:
         """Initialize reranker service."""
         self.model_name = model_name
         self.use_onnx = use_onnx
-        self.device = device
         self.batch_size = batch_size
         self.max_length = max_length
 
@@ -287,7 +279,6 @@ class RerankerService:
             if use_onnx:
                 self.reranker = ONNXCrossEncoderReranker(
                     model_name=model_name,
-                    device=device,
                     batch_size=batch_size,
                     max_length=max_length,
                     cache_dir=cache_dir,
@@ -297,7 +288,6 @@ class RerankerService:
             else:
                 self.reranker = CrossEncoderReranker(
                     model_name=model_name,
-                    device=device,
                     batch_size=batch_size,
                     max_length=max_length,
                 )
@@ -345,7 +335,6 @@ class RerankerService:
 def create_reranker(
     model_name: str = "cl-nagoya/ruri-reranker-small",
     use_onnx: bool = True,
-    device: str = "cpu",
     batch_size: int = 8,
     max_length: int = 512,
     cache_dir: Optional[Path] = None,
@@ -356,7 +345,6 @@ def create_reranker(
     if use_onnx:
         return ONNXCrossEncoderReranker(
             model_name=model_name,
-            device=device,
             batch_size=batch_size,
             max_length=max_length,
             cache_dir=cache_dir,
@@ -366,7 +354,6 @@ def create_reranker(
     else:
         return CrossEncoderReranker(
             model_name=model_name,
-            device=device,
             batch_size=batch_size,
             max_length=max_length,
         )

--- a/tests/common/test_model_manager.py
+++ b/tests/common/test_model_manager.py
@@ -23,14 +23,12 @@ class TestModelManager:
         # Create concrete implementations for testing
         manager1 = EmbeddingModelManager(
             model_name="test-model",
-            device="cpu",
             use_onnx=True,
             max_seq_length=512,
         )
         
         manager2 = EmbeddingModelManager(
             model_name="test-model",
-            device="cpu",
             use_onnx=True,
             max_seq_length=512,
         )
@@ -41,7 +39,6 @@ class TestModelManager:
         # Different configuration should generate different cache key
         manager3 = EmbeddingModelManager(
             model_name="test-model",
-            device="cpu",
             use_onnx=False,  # Changed to different config to generate different key
             max_seq_length=512,
         )
@@ -318,7 +315,6 @@ class TestCreateModelManager:
         manager = create_model_manager(
             "embedding",
             "test-model",
-            device="cpu",
             use_onnx=True,
             max_seq_length=512,
         )
@@ -333,14 +329,13 @@ class TestCreateModelManager:
         manager = create_model_manager(
             "reranker",
             "test-reranker",
-            device="cpu",  # Fixed to CPU only
             use_onnx=False,
             max_length=256,
         )
         
         assert isinstance(manager, RerankerModelManager)
         assert manager.model_name == "test-reranker"
-        assert manager.device == "cpu"  # Fixed to CPU only
+        assert manager.device == "cpu"  # Always CPU-only
         assert manager.use_onnx is False
 
     def test_create_invalid_type(self):

--- a/tests/indexer/config/test_config.py
+++ b/tests/indexer/config/test_config.py
@@ -20,7 +20,6 @@ class TestIndexerConfig:
         assert config.chunk_size == 1024
         assert config.chunk_overlap == 256
         assert config.embedding_model == "cl-nagoya/ruri-v3-30m"
-        assert config.embedding_device == "cpu"
         assert config.use_reranker is False
 
     def test_config_with_custom_values(self) -> None:
@@ -28,7 +27,6 @@ class TestIndexerConfig:
         # Create custom sub-configs
         model_config = ModelConfig(
             embedding_model="custom-model",
-            embedding_device="cpu",  # Fixed to CPU only
             use_onnx=False,
         )
         
@@ -53,7 +51,6 @@ class TestIndexerConfig:
         assert config.chunk_size == 512
         assert config.chunk_overlap == 128
         assert config.embedding_model == "custom-model"
-        assert config.embedding_device == "cpu"  # Fixed to CPU only
         assert config.use_reranker is True
         assert str(config.db_path) == "custom.db"
 


### PR DESCRIPTION
## Summary
This PR implements the removal of GPU support as requested in #147, enforcing CPU-only device configuration throughout the codebase.

### Implementation Approach
The implementation evolved through two phases based on feedback:

1. **Initial approach**: Restricted device configuration to CPU-only using `Literal["cpu"]` type
2. **Final approach**: Complete removal of device parameters from the API surface (as suggested: "そもそも、各関数の引数からも削除すべきでは？")

### Changes Made

#### Complete Device Parameter Removal
- Removed `device` parameter from all `ModelManager` constructors
- Removed `device` parameter from `EmbeddingService` and `RerankerService` 
- Removed `embedding_device` field from configuration schemas entirely
- Added `extra="forbid"` to Pydantic models to reject any device configuration attempts
- Updated all factory functions to remove device parameters
- Fixed all tests to remove device-related assertions and parameters

#### Internal CPU Enforcement
- `ModelManager` now hardcodes `self.device = "cpu"` internally
- All model loading explicitly uses `device="cpu"`
- Removed device validation logic as it's no longer needed

### Architecture Compatibility
This PR has been rebased on the latest main branch and is fully compatible with:
- The new indexer/retriever architecture separation (#153)
- HuggingFace error handling improvements (#151)

### Benefits
- **Clean API**: No confusing device parameters that are ignored
- **Clear intent**: CPU-only operation is explicit at the API level
- **Future-proof**: No risk of accidentally reintroducing GPU support
- **Type safety**: Pydantic validation prevents device configuration attempts

### Breaking Changes
⚠️ This is a breaking change for any code that passes device parameters:

```python
# Before (will break)
embedding_service = EmbeddingService(model_name="...", device="cpu")
model_manager = EmbeddingModelManager(model_name="...", device="cuda")

# After (correct usage)
embedding_service = EmbeddingService(model_name="...")
model_manager = EmbeddingModelManager(model_name="...")
```

### Migration Guide
1. Remove any `device` parameter from `EmbeddingService`, `RerankerService`, or `ModelManager` instantiations
2. Remove `embedding_device` from configuration files
3. Remove any device-related configuration or validation logic

### Testing
- All tests updated and passing
- Verified that device configuration attempts are rejected with clear errors
- Confirmed CPU-only operation throughout the codebase
- Compatible with the new retriever architecture

Closes #147

🤖 Generated with [Claude Code](https://claude.ai/code)