### PR TITLE
feat: set up GitHub Pages documentation site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,46 @@
+title: Oboyu Documentation
+description: Japanese-enhanced semantic search system for your local documents
+baseurl: "/oboyu"
+url: "https://sonesuke.github.io"
+
+# Theme configuration
+theme: minima
+markdown: kramdown
+highlighter: rouge
+
+# Plugins
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Navigation
+header_pages:
+  - quickstart.md
+  - cli.md
+  - configuration.md
+  - architecture.md
+  - troubleshooting.md
+
+# SEO and metadata
+author: sonesuke
+github_username: sonesuke
+repository: sonesuke/oboyu
+
+# Exclude files from processing
+exclude:
+  - assets/demo.tape
+  - README.md
+  - CONTRIBUTING.md
+  - LICENSE.md
+
+# Markdown processing
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    css_class: 'highlight'
+    block:
+      line_numbers: false
+
+# Analytics (optional - can be added later)
+# google_analytics: UA-XXXXXXXXX-X

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# Oboyu Documentation
+
+Welcome to the Oboyu documentation! Oboyu is a Japanese-enhanced semantic search system for your local documents.
+
+## Getting Started
+
+- [**Quickstart Guide**](quickstart.md) - Get up and running with Oboyu in minutes
+- [**CLI Reference**](cli.md) - Complete command-line interface documentation
+- [**Configuration**](configuration.md) - Configure Oboyu to meet your needs
+
+## Core Features
+
+- [**Indexer**](indexer.md) - Learn how Oboyu indexes your documents
+- [**Query Engine**](query_engine.md) - Understanding the search capabilities
+- [**Crawler**](crawler.md) - Document discovery and processing
+- [**Reranker**](reranker.md) - Advanced result ranking features
+
+## Advanced Topics
+
+- [**Architecture Overview**](architecture.md) - Technical architecture and design
+- [**Japanese Language Support**](japanese.md) - Special features for Japanese text
+- [**MCP Server Integration**](mcp_server.md) - Model Context Protocol support
+- [**Configuration Migration**](immutable-configuration-migration.md) - Migrating to the new configuration system
+
+## Help & Support
+
+- [**Troubleshooting**](troubleshooting.md) - Common issues and solutions
+
+## Features
+
+Oboyu provides:
+- 🔍 Fast semantic search across your local documents
+- 🇯🇵 Enhanced Japanese language processing
+- 🚀 High-performance indexing and retrieval
+- 🔧 Flexible configuration options
+- 🤖 MCP server integration for AI assistants
+
+## Quick Links
+
+- [GitHub Repository](https://github.com/sonesuke/oboyu)
+- [Issue Tracker](https://github.com/sonesuke/oboyu/issues)
+- [Contributing Guidelines](https://github.com/sonesuke/oboyu/blob/main/CONTRIBUTING.md)
+
+## License
+
+Oboyu is open source software licensed under the [MIT License](https://github.com/sonesuke/oboyu/blob/main/LICENSE.md).


### PR DESCRIPTION
## Summary
- Implements GitHub Pages setup for hosting project documentation
- Creates landing page with organized navigation to all documentation sections
- Configures Jekyll with minima theme for professional presentation

## Changes
- Added `docs/index.md` - Main landing page with:
  - Welcome message and project description
  - Organized navigation sections (Getting Started, Core Features, Advanced Topics, Help & Support)
  - Quick links to GitHub repository and issue tracker
  - Feature highlights

- Added `docs/_config.yml` - Jekyll configuration with:
  - Site metadata (title, description, baseurl)
  - Minima theme for clean, responsive design
  - SEO and sitemap plugins for better discoverability
  - Proper markdown processing settings
  - Exclusion rules for non-documentation files

## Testing
- Validated all internal documentation links exist and are correctly referenced
- Ensured proper file structure for GitHub Pages deployment from `/docs` folder

## Next Steps
After merging this PR:
1. Go to repository Settings → Pages
2. Set source to "Deploy from a branch"
3. Select branch: `main`, folder: `/docs`
4. Documentation will be accessible at https://sonesuke.github.io/oboyu/

Closes #177

🤖 Generated with [Claude Code](https://claude.ai/code)