### PR TITLE
Fix TestPyPI upload failure by configuring hatch-vcs to exclude local version identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ sources = ["src"]
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { local_scheme = "no-local-version", fallback_version = "0.1.0" }
 
 # Remove [tool.uv.sources] as it's causing conflicts
 # The package should be installed in editable mode via uv sync or uv pip install -e .


### PR DESCRIPTION
## Summary
- Configure hatch-vcs to generate TestPyPI-compatible version strings
- Remove local version identifiers (the `+gXXXXXXX` suffix) from generated versions
- This ensures packages can be successfully uploaded to TestPyPI

## Problem
GitHub Actions was failing to upload packages to TestPyPI because the generated version `0.1.dev1+gf95d081` contained a local version identifier which TestPyPI doesn't accept.

## Solution
Updated `pyproject.toml` to configure hatch-vcs with:
- `local_scheme = "no-local-version"` to remove the `+gXXXXXXX` suffix
- `fallback_version = "0.1.0"` as the base version when no Git tags exist

This generates TestPyPI-compatible versions like `0.1.dev106` instead of `0.1.dev1+gf95d081`.

## Test plan
- [x] Updated pyproject.toml configuration
- [x] Verified build generates version without local identifier (`0.1.dev106`)
- [x] All lint and type checks pass
- [ ] TestPyPI upload will succeed in GitHub Actions after merge

Fixes #194

🤖 Generated with [Claude Code](https://claude.ai/code)