### PR TITLE
Fix progress percentage inconsistency for completed tasks

### DIFF
--- a/src/oboyu/cli/progress.py
+++ b/src/oboyu/cli/progress.py
@@ -142,6 +142,10 @@ class ProgressPipeline:
 
         # Auto-complete when reaching total
         if stage.total and current >= stage.total:
+            # Ensure final progress message shows 100% before completion
+            if stage.operation_id:
+                final_message = self._format_progress_message(stage)
+                self.logger.update_operation(stage.operation_id, final_message)
             self.complete_stage(stage_name)
 
     def complete_stage(self, name: str) -> None:

--- a/tests/cli/test_progress.py
+++ b/tests/cli/test_progress.py
@@ -117,6 +117,27 @@ class TestProgressPipeline:
         
         mock_logger.complete_operation.assert_called_once_with("op_id_123")
 
+    def test_completion_shows_100_percent(self, pipeline, mock_logger):
+        """Test that completion always shows 100% progress before marking complete."""
+        pipeline.add_stage("test_stage", "Test Stage", total=100)
+        mock_logger.start_operation.return_value = "op_id_123"
+        
+        # Update to total should show final progress message with 100%
+        pipeline.update("test_stage", 100, 100)
+        
+        # Should have called update_operation twice:
+        # 1. When auto-starting the stage 
+        # 2. Final progress message with 100% before completion
+        assert mock_logger.update_operation.call_count == 2
+        
+        # Check the final call shows 100%
+        final_call_args = mock_logger.update_operation.call_args_list[-1]
+        final_message = final_call_args[0][1]  # Second argument is the message
+        assert "100%" in final_message
+        
+        # Should then mark as complete
+        mock_logger.complete_operation.assert_called_once_with("op_id_123")
+
 
 class TestIndexerProgressAdapter:
     """Test IndexerProgressAdapter class."""


### PR DESCRIPTION
## Summary
- Fix race condition where completed tasks showed inconsistent progress (✓ with 0% instead of 100%)
- Ensure final progress message always displays 100% before completion checkmark appears

## Problem Fixed
Previously, completed operations displayed contradictory status where checkmarks (✓) appeared alongside old progress percentages like "0/2 (0%)" instead of the expected "2/2 (100%)". This was caused by a race condition in the progress tracking system.

## Solution
Modified the auto-completion logic in `ProgressPipeline.update()` to:
1. Always update the progress message to show 100% completion 
2. Then mark the operation as complete with the checkmark

This ensures users see consistent progress indicators that match the completion status.

## Test Plan
- [x] Added test case `test_completion_shows_100_percent` to verify 100% is shown before completion
- [x] Verified all existing progress tests still pass
- [x] Ran linting and type checking successfully
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.ai/code)