### PR TITLE
fix: enable --config option to work when placed after directory arguments (#188)

### DIFF
--- a/src/oboyu/cli/index.py
+++ b/src/oboyu/cli/index.py
@@ -10,6 +10,7 @@ import typer
 from typing_extensions import Annotated
 
 from oboyu.cli.base import BaseCommand
+from oboyu.cli.common_options import ConfigOption
 from oboyu.cli.index_config import create_crawler_config
 from oboyu.cli.services.indexing_service import IndexingService
 
@@ -17,6 +18,9 @@ app = typer.Typer(
     help="Index documents for search",
     pretty_exceptions_enable=False,
     rich_markup_mode=None,
+    context_settings={
+        "allow_interspersed_args": True,
+    },
 )
 
 DirectoryOption = Annotated[
@@ -46,6 +50,7 @@ EncodingDetectionOption = Annotated[
 def index(
     ctx: typer.Context,
     directories: DirectoryOption,
+    config: ConfigOption = None,
     recursive: Optional[bool] = True,
     include_patterns: Optional[List[str]] = None,
     exclude_patterns: Optional[List[str]] = None,

--- a/src/oboyu/cli/manage.py
+++ b/src/oboyu/cli/manage.py
@@ -10,12 +10,16 @@ import typer
 from typing_extensions import Annotated
 
 from oboyu.cli.base import BaseCommand
+from oboyu.cli.common_options import ConfigOption
 from oboyu.cli.services.indexing_service import IndexingService
 
 app = typer.Typer(
     help="Manage the index database",
     pretty_exceptions_enable=False,
     rich_markup_mode=None,
+    context_settings={
+        "allow_interspersed_args": True,
+    },
 )
 
 DirectoryOption = Annotated[
@@ -33,6 +37,7 @@ DirectoryOption = Annotated[
 @app.command(name="clear")
 def clear(
     ctx: typer.Context,
+    config: ConfigOption = None,
     db_path: Optional[Path] = None,
     force: bool = False,
 ) -> None:
@@ -74,6 +79,7 @@ def clear(
 def status(
     ctx: typer.Context,
     directories: DirectoryOption,
+    config: ConfigOption = None,
     db_path: Optional[Path] = None,
     detailed: Annotated[
         bool,
@@ -138,6 +144,7 @@ def status(
 def diff(
     ctx: typer.Context,
     directories: DirectoryOption,
+    config: ConfigOption = None,
     db_path: Optional[Path] = None,
     change_detection: Annotated[
         Optional[str],


### PR DESCRIPTION
## Summary

- Fix critical CLI argument parsing issue where `--config` option was incorrectly parsed as a directory argument when placed after positional directory arguments
- Enable `oboyu index . --config /path/to/config.yaml` syntax to work correctly by adding `allow_interspersed_args: True` to Typer context settings
- Add explicit config parameter to index, status, and diff commands for proper option handling

## Test plan

- [x] Test `oboyu index . --config /invalid/config.yaml` now shows proper config file error instead of directory error
- [x] Test `oboyu index --config /path/to/config.yaml .` still works (original order)
- [x] Test `oboyu index . --config valid_config.yaml` works correctly with valid config
- [x] Run all fast tests to ensure no regressions (779 passed, 44 skipped)
- [x] Verify type checking and linting pass

🤖 Generated with [Claude Code](https://claude.ai/code)