### PR TITLE
fix: improve database clearing and corruption recovery for integration tests

### DIFF
--- a/tests/integration/test_cross_process_database.py
+++ b/tests/integration/test_cross_process_database.py
@@ -388,7 +388,7 @@ class TestCrossProcessDatabase:
             new_indexer.database_service.store_chunks(new_chunks)
             chunk_ids = [chunk.id for chunk in new_chunks]
             contents = [chunk.content for chunk in new_chunks]
-            embeddings = new_indexer.embedding_service.create_embeddings(contents)
+            embeddings = new_indexer.embedding_service.generate_embeddings(contents)
             new_indexer.database_service.store_embeddings(chunk_ids, embeddings)
             new_indexer.database_service.ensure_hnsw_index()
             


### PR DESCRIPTION
## Summary
- Fix foreign key constraint issues in clear_database() by using separate transactions for each table deletion
- Add database corruption recovery in DatabaseStateManager to handle corrupted files  
- Fix test typo: use generate_embeddings instead of create_embeddings
- Implement proper deletion order respecting foreign key constraints

## Test plan
- [x] Integration tests for database clearing now pass
- [x] Database corruption recovery tests pass
- [x] Pre-commit hooks pass (linting, formatting, type checking)

🤖 Generated with [Claude Code](https://claude.ai/code)