### PR TITLE
Fix GitHub Actions Node.js caching error in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,22 +27,22 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: website/package-lock.json
+          cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
         run: |
-          cd website
+          cd docs
           npm ci
 
       - name: Build website
         run: |
-          cd website
+          cd docs
           npm run build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./website/build
+          path: ./docs/build
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- Fixed Node.js cache dependency path error in deploy-docs.yml workflow
- Updated all paths from `website/` to `docs/` directory following documentation consolidation in PR #234

## Problem
The deploy-docs workflow was failing with the error:
```
Some specified paths were not resolved, unable to cache dependencies.
```

This occurred because:
- The workflow referenced `website/package-lock.json` for Node.js caching
- However, after PR #234 consolidated the documentation, the actual location is `docs/package-lock.json`

## Solution
Updated `.github/workflows/deploy-docs.yml` to correct all directory references:
- Node.js cache path: `website/package-lock.json` → `docs/package-lock.json`
- npm install/build directory: `cd website` → `cd docs`
- Build artifact path: `./website/build` → `./docs/build`

## Test plan
- [ ] CI passes successfully with properly cached Node.js dependencies
- [ ] Documentation deploys correctly to GitHub Pages

Fixes #237

🤖 Generated with [Claude Code](https://claude.ai/code)