### PR TITLE
Fix #254 - Add use case documentation for Nikkei 225 securities reports search

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
         'use-cases/meeting-notes',
         'use-cases/research-papers',
         'use-cases/personal-notes',
+        'use-cases/nikkei225-securities-reports',
       ],
     },
     {

--- a/docs/use-cases/nikkei225-securities-reports.md
+++ b/docs/use-cases/nikkei225-securities-reports.md
@@ -382,5 +382,5 @@ oboyu query --query "経済成長 economic growth GDP連動" --mode hybrid
 
 - Explore [Research Paper Search](research-papers.md) for academic financial research
 - Learn about [Meeting Notes Search](meeting-notes.md) for investment committee documentation  
-- Set up [PDF Processing](../technical-setup/pdf-processing.md) for advanced document handling
 - Configure [Automation](../integration-automation/automation.md) for regular report updates
+- Review [Basic Usage](../basic-usage/document-types.md) for PDF processing capabilities

--- a/docs/use-cases/nikkei225-securities-reports.md
+++ b/docs/use-cases/nikkei225-securities-reports.md
@@ -1,0 +1,386 @@
+---
+id: nikkei225-securities-reports
+title: Nikkei 225 Securities Reports Search
+sidebar_position: 5
+---
+
+# Nikkei 225 Securities Reports Search
+
+Master the art of searching through Nikkei 225 companies' securities reports (有価証券報告書) for comprehensive investment research, financial analysis, and corporate intelligence using Oboyu.
+
+## Scenario: Investment Research Analyst
+
+You're analyzing Nikkei 225 companies for investment decisions, requiring deep dives into financial statements, risk factors, business strategies, and competitive positioning across Japan's top public companies.
+
+### Setting Up Your Securities Reports Index
+
+```bash
+# Index downloaded Nikkei 225 securities reports
+oboyu index ~/financial-data/nikkei225-reports --db-path ~/indexes/nikkei225.db \
+    --include "*.pdf" \
+    --include "*.txt" \
+    --recursive
+
+# Update with quarterly reports
+oboyu index ~/financial-data/quarterly-reports --db-path ~/indexes/nikkei225.db --update
+
+# Index translated reports (if available)
+oboyu index ~/financial-data/translated-reports --db-path ~/indexes/nikkei225-en.db
+```
+
+### Financial Performance Analysis
+
+#### Revenue and Profit Searches
+```bash
+# Find revenue trends across companies
+oboyu query --query "売上高 revenue 増収" --db-path ~/indexes/nikkei225.db --mode vector
+
+# Search for profit margin analysis
+oboyu query --query "営業利益率 operating margin 収益性" --mode hybrid
+
+# Find growth metrics
+oboyu query --query "成長率 growth rate YoY前年同期比" --db-path ~/indexes/nikkei225.db
+```
+
+#### Sector-Specific Financial Analysis
+```bash
+# Technology sector performance
+oboyu query --query "情報技術 IT technology sector デジタル" --mode vector
+
+# Automotive industry analysis
+oboyu query --query "自動車 automotive 車両 トヨタ ホンダ" --db-path ~/indexes/nikkei225.db
+
+# Financial services sector
+oboyu query --query "金融サービス banking 銀行 証券" --mode hybrid
+```
+
+## Scenario: Financial Journalist
+
+Investigating corporate developments, governance issues, and market trends for financial media coverage and industry analysis.
+
+### Corporate Governance Research
+
+#### Executive Compensation Analysis
+```bash
+# Find executive pay information
+oboyu query --query "役員報酬 executive compensation CEO salary" --mode vector
+
+# Search for board composition
+oboyu query --query "取締役会 board directors 独立取締役" --db-path ~/indexes/nikkei225.db
+
+# Find governance reforms
+oboyu query --query "コーポレートガバナンス governance reform 株主" --mode hybrid
+```
+
+#### ESG and Sustainability Reporting
+```bash
+# Environmental initiatives
+oboyu query --query "環境 environmental sustainability 脱炭素" --mode vector
+
+# Social responsibility programs  
+oboyu query --query "CSR social responsibility 社会貢献" --db-path ~/indexes/nikkei225.db
+
+# Governance improvements
+oboyu query --query "内部統制 internal control compliance" --mode hybrid
+```
+
+## Scenario: Academic Researcher
+
+Conducting scholarly research on Japanese corporate behavior, financial markets, and economic trends using comprehensive corporate disclosure data.
+
+### Business Strategy Analysis
+
+#### R&D and Innovation Research
+```bash
+# Research and development investments
+oboyu query --query "研究開発 R&D innovation 技術開発" --mode vector
+
+# Digital transformation initiatives
+oboyu query --query "DX digital transformation デジタル化" --db-path ~/indexes/nikkei225.db
+
+# Patent and intellectual property
+oboyu query --query "特許 patent 知的財産 IP intellectual property" --mode hybrid
+```
+
+#### Market Expansion Studies
+```bash
+# International expansion strategies
+oboyu query --query "海外展開 international expansion global" --mode vector
+
+# Merger and acquisition activities
+oboyu query --query "M&A merger acquisition 買収 統合" --db-path ~/indexes/nikkei225.db
+
+# Partnership and alliance formations
+oboyu query --query "提携 partnership alliance 協業" --mode hybrid
+```
+
+## Scenario: Individual Investor
+
+Personal investment research for portfolio construction and stock selection within Japan's premier market index.
+
+### Investment Decision Support
+
+#### Risk Assessment
+```bash
+# Find risk factor disclosures
+oboyu query --query "リスク要因 risk factors 事業リスク" --mode vector
+
+# Search for market volatility concerns
+oboyu query --query "市場変動 market volatility 不確実性" --db-path ~/indexes/nikkei225.db
+
+# Currency and international exposure
+oboyu query --query "為替リスク currency risk 外国為替" --mode hybrid
+```
+
+#### Dividend and Shareholder Returns
+```bash
+# Dividend policy and history
+oboyu query --query "配当 dividend 株主還元 payout" --mode vector
+
+# Share buyback programs
+oboyu query --query "自社株買い share buyback 株式消却" --db-path ~/indexes/nikkei225.db
+
+# Shareholder value creation
+oboyu query --query "株主価値 shareholder value ROE ROA" --mode hybrid
+```
+
+## Advanced Search Patterns
+
+### Cross-Company Comparisons
+
+#### Competitive Analysis
+```bash
+# Compare similar companies in same sector
+oboyu query --query "競合他社 competitor analysis 市場シェア" --mode vector
+
+# Industry positioning searches
+oboyu query --query "業界地位 market position リーダー" --db-path ~/indexes/nikkei225.db
+
+# Benchmarking against peers
+oboyu query --query "ベンチマーク benchmark 同業他社比較" --mode hybrid
+```
+
+#### Financial Ratio Analysis
+```bash
+# Profitability ratios across companies
+oboyu query --query "ROE ROA 収益性指標 profitability" --mode vector
+
+# Liquidity and solvency metrics
+oboyu query --query "流動比率 debt ratio 財務健全性" --db-path ~/indexes/nikkei225.db --mode hybrid
+
+# Efficiency and activity ratios
+oboyu query --query "総資産回転率 efficiency ratio 効率性" --mode vector
+```
+
+### Time-Series Analysis
+
+#### Trend Analysis Over Time
+```bash
+# Multi-year performance trends
+oboyu query --query "3年間 5年間 long-term trend 長期推移" --mode vector
+
+# Quarterly progression analysis
+oboyu query --query "四半期 quarterly progression 季節性" --db-path ~/indexes/nikkei225.db
+
+# Economic cycle impact
+oboyu query --query "景気循環 economic cycle 景況感" --mode hybrid
+```
+
+#### Historical Event Analysis
+```bash
+# COVID-19 impact on businesses
+oboyu query --query "COVID-19 pandemic impact コロナ影響" --mode vector
+
+# Natural disaster resilience
+oboyu query --query "災害対応 disaster recovery BCP" --db-path ~/indexes/nikkei225.db
+
+# Regulatory change adaptation
+oboyu query --query "規制変更 regulatory change 法改正" --mode hybrid
+```
+
+## Real-World Example: Quarterly Earnings Analysis
+
+Complete workflow for analyzing quarterly earnings across Nikkei 225 companies:
+
+```bash
+# 1. Find companies reporting strong quarterly results
+oboyu query --query "四半期決算 quarterly earnings 増益" --db-path ~/indexes/nikkei225.db
+
+# 2. Analyze revenue growth drivers
+oboyu query --query "売上増加要因 revenue growth drivers 成長要因" --mode vector
+
+# 3. Examine margin expansion stories
+oboyu query --query "利益率改善 margin expansion コスト削減" --mode hybrid
+
+# 4. Identify forward guidance and outlook
+oboyu query --query "業績予想 earnings guidance 見通し" --db-path ~/indexes/nikkei225.db
+
+# 5. Check for special items and one-time charges
+oboyu query --query "特別損益 extraordinary items 一時的" --mode vector
+
+# 6. Research management commentary and strategy
+oboyu query --query "経営陣コメント management commentary 経営方針" --mode hybrid
+```
+
+## Japanese Language Search Optimization
+
+### Effective Japanese Search Terms
+```bash
+# Financial terminology combinations
+oboyu query --query "財務諸表 financial statements 貸借対照表" --mode vector
+
+# Business performance keywords
+oboyu query --query "業績 performance 売上 profit 利益" --db-path ~/indexes/nikkei225.db
+
+# Strategic terminology
+oboyu query --query "経営戦略 business strategy 事業戦略" --mode hybrid
+```
+
+### Mixed Language Searches
+```bash
+# Japanese-English hybrid searches
+oboyu query --query "DX digital デジタル transformation" --mode vector
+
+# Technical terms in both languages  
+oboyu query --query "AI artificial intelligence 人工知能" --db-path ~/indexes/nikkei225.db
+
+# Financial metrics hybrid
+oboyu query --query "ROE return equity 自己資本利益率" --mode hybrid
+```
+
+## Workflow Integration Examples
+
+### Due Diligence Research
+```bash
+# Comprehensive company analysis workflow
+oboyu query --query "会社概要 company overview 事業内容" --db-path ~/indexes/nikkei225.db
+oboyu query --query "財務状況 financial condition 資産負債" --mode vector
+oboyu query --query "リスク要因 risk factors 懸念事項" --mode hybrid
+oboyu query --query "成長戦略 growth strategy 将来性" --db-path ~/indexes/nikkei225.db
+```
+
+### Investment Screening Process
+```bash
+# Quality company identification
+oboyu query --query "優良企業 quality company 安定収益" --mode vector
+
+# Value investment opportunities
+oboyu query --query "割安株 undervalued バリュー" --db-path ~/indexes/nikkei225.db
+
+# Growth investment candidates
+oboyu query --query "成長株 growth stock 高成長" --mode hybrid
+```
+
+### Competitive Intelligence
+```bash
+# Market share analysis
+oboyu query --query "市場シェア market share トップシェア" --mode vector
+
+# Competitive advantage research
+oboyu query --query "競争優位 competitive advantage 差別化" --db-path ~/indexes/nikkei225.db
+
+# Industry disruption monitoring
+oboyu query --query "業界変革 industry disruption 新技術" --mode hybrid
+```
+
+## Tips and Best Practices
+
+### Document Management
+1. **Organize by Year and Quarter**: Structure reports in `YYYY/QQ/` folders
+2. **Company Code Naming**: Use TSE codes in filenames (e.g., `7203_toyota_2024Q1.pdf`)
+3. **Language Separation**: Keep Japanese and English reports in separate databases
+4. **Regular Updates**: Maintain quarterly update schedule for fresh data
+
+### Search Optimization
+1. **Combine Keywords**: Use both Japanese and English terms for comprehensive results
+2. **Vector Mode for Concepts**: Use vector search for thematic analysis
+3. **Hybrid for Precision**: Combine exact terms with semantic search
+4. **Context Awareness**: Consider business cycle timing in search strategies
+
+### Analysis Workflows
+1. **Multi-Stage Analysis**: Start broad, then narrow to specific insights  
+2. **Cross-Reference Sources**: Validate findings across multiple company reports
+3. **Historical Context**: Always compare with previous periods
+4. **Sector Comparisons**: Benchmark against industry peers
+
+## Integration with Financial Analysis Tools
+
+### Excel and Spreadsheet Integration
+```bash
+# Export search results for analysis
+oboyu query --query "財務指標 financial metrics" --db-path ~/indexes/nikkei225.db > financial_data.txt
+
+# Generate company comparison data
+oboyu query --query "同業他社 peer comparison" --mode vector > peer_analysis.txt
+```
+
+### BI Tool Integration
+```bash
+# Create standardized search functions
+nikkei_search() {
+    oboyu query --query "$1" --db-path ~/indexes/nikkei225.db --mode "$2"
+}
+
+# Use in automated reports
+nikkei_search "quarterly results" "vector"
+nikkei_search "業績予想" "hybrid"
+```
+
+## Regulatory Compliance and Legal Research
+
+### Disclosure Requirement Analysis
+```bash
+# Find mandatory disclosure items
+oboyu query --query "開示要項 disclosure requirements 法定開示" --mode vector
+
+# Research compliance status
+oboyu query --query "コンプライアンス compliance 法令遵守" --db-path ~/indexes/nikkei225.db
+
+# Regulatory filing analysis
+oboyu query --query "有価証券報告書 securities report 法定書類" --mode hybrid
+```
+
+### Legal Risk Assessment
+```bash
+# Litigation and legal issues
+oboyu query --query "訴訟 litigation 法的リスク" --mode vector
+
+# Regulatory sanctions and penalties
+oboyu query --query "制裁 penalty 行政処分" --db-path ~/indexes/nikkei225.db
+
+# Compliance violations
+oboyu query --query "違反 violation コンプライアンス違反" --mode hybrid
+```
+
+## Market Intelligence and Sector Analysis
+
+### Industry Trend Identification
+```bash
+# Emerging technology adoption
+oboyu query --query "新技術導入 technology adoption イノベーション" --mode vector
+
+# Market disruption signals
+oboyu query --query "市場変化 market disruption 構造変化" --db-path ~/indexes/nikkei225.db
+
+# Consumer behavior shifts
+oboyu query --query "消費者動向 consumer behavior 需要変化" --mode hybrid
+```
+
+### Economic Indicator Correlation
+```bash
+# Interest rate sensitivity analysis
+oboyu query --query "金利感応度 interest rate sensitivity 金融政策" --mode vector
+
+# Currency impact assessment
+oboyu query --query "為替影響 currency impact 円安円高" --db-path ~/indexes/nikkei225.db
+
+# Economic growth correlation
+oboyu query --query "経済成長 economic growth GDP連動" --mode hybrid
+```
+
+## Next Steps
+
+- Explore [Research Paper Search](research-papers.md) for academic financial research
+- Learn about [Meeting Notes Search](meeting-notes.md) for investment committee documentation  
+- Set up [PDF Processing](../technical-setup/pdf-processing.md) for advanced document handling
+- Configure [Automation](../integration-automation/automation.md) for regular report updates


### PR DESCRIPTION
Fixes #254

## 🎯 Problem
Create comprehensive use case documentation showing how to use Oboyu to search through Nikkei 225 companies' securities reports (有価証券報告書) for investment research and corporate analysis.

## 💡 Solution Approach
- Research existing documentation patterns and style
- Create detailed use case article following established format
- Include practical search examples for financial document analysis
- Provide setup instructions and advanced search patterns
- Target investment analysts, researchers, and financial professionals

## 📋 Progress Checklist  
- [x] Initial setup and worktree environment
- [x] Analysis of existing documentation patterns
- [ ] Research Nikkei 225 and securities reports context
- [ ] Write comprehensive use case documentation article
- [ ] Review content structure against requirements
- [ ] Quality checks and testing
- [ ] Documentation validation

## 🔗 Related
- Issue: #254
- Branch: 254-nikkei225-securities-reports
- Worktree: /Users/sonesuke/oboyu/main/.worktree/issue-254