### PR TITLE
Fix #307 - Remove unnecessary oboyu kg validate command

### DIFF
--- a/src/oboyu/adapters/kg_extraction/llm_kg_extraction_service.py
+++ b/src/oboyu/adapters/kg_extraction/llm_kg_extraction_service.py
@@ -462,17 +462,6 @@ JSON形式のみで回答してください:"""
 
         return self._model_loaded and self._llm is not None
 
-    async def validate_extraction_schema(self) -> bool:
-        """Validate that the model can produce valid JSON schema output."""
-        # First check if model is loaded
-        if not self.is_model_loaded():
-            logger.warning("Model not loaded during schema validation")
-            return False
-
-        # For now, just check model loading - actual inference validation takes too long
-        logger.info("Model validation passed (lightweight check - model is loaded and ready)")
-        return True
-
     def __del__(self) -> None:
         """Cleanup resources."""
         if self._llm is not None:

--- a/src/oboyu/application/kg/kg_service.py
+++ b/src/oboyu/application/kg/kg_service.py
@@ -294,35 +294,6 @@ class KnowledgeGraphService:
             logger.error(f"Failed to get KG stats: {e}")
             raise ServiceError(f"Failed to get statistics: {e}")
 
-    async def validate_extraction_service(self) -> bool:
-        """Validate that the extraction service is working properly.
-
-        Returns:
-            True if service is ready for use
-
-        """
-        try:
-            # Check if model is loaded
-            is_loaded = self.extraction_service.is_model_loaded()
-            logger.info(f"Model loaded status: {is_loaded}")
-
-            if not is_loaded:
-                logger.warning("Extraction model is not loaded")
-                return False
-
-            # Check schema validation
-            logger.info("Starting schema validation...")
-            schema_valid = await self.extraction_service.validate_extraction_schema()
-            logger.info(f"Schema validation result: {schema_valid}")
-
-            return schema_valid
-        except Exception as e:
-            logger.error(f"Extraction service validation failed: {e}")
-            import traceback
-
-            logger.error(f"Validation traceback: {traceback.format_exc()}")
-            return False
-
     async def deduplicate_all_entities(
         self,
         entity_type: Optional[str] = None,

--- a/src/oboyu/cli/commands/kg.py
+++ b/src/oboyu/cli/commands/kg.py
@@ -118,7 +118,6 @@ def build(
     full: bool = typer.Option(False, "--full", help="Rebuild entire knowledge graph"),
     batch_size: Optional[int] = typer.Option(None, "--batch-size", help="Processing batch size"),
     limit: Optional[int] = typer.Option(None, "--limit", help="Limit number of chunks to process"),
-    skip_validation: bool = typer.Option(False, "--skip-validation", help="Skip extraction service validation"),
 ) -> None:
     """Build knowledge graph from existing chunks."""
 
@@ -137,22 +136,6 @@ def build(
             config_manager = command.get_config_manager()
             config_data = config_manager.get_section("indexer")
             kg_service = await command._get_kg_service(config_data)
-
-            # Validate extraction service with detailed logging
-            command.console.print("🔍 Validating extraction service...")
-            try:
-                validation_result = await kg_service.validate_extraction_service()
-                if not validation_result:
-                    command.console.print("[red]❌ Extraction service validation returned False[/red]")
-                    raise typer.Exit(1)
-                command.console.print("[green]✅ Extraction service validated[/green]")
-            except Exception as e:
-                command.console.print(f"[red]❌ Validation failed with exception: {e}[/red]")
-                import traceback
-
-                logger.error(f"KG validation failed: {e}")
-                logger.error(f"Full traceback: {traceback.format_exc()}")
-                raise typer.Exit(1)
 
             # Get chunks to process
             if full:
@@ -308,33 +291,6 @@ def stats(ctx: typer.Context) -> None:
                 logger.debug(f"Error during cleanup: {cleanup_error}")
 
     asyncio.run(_stats())
-
-
-@app.command()
-def validate(ctx: typer.Context) -> None:
-    """Validate knowledge graph extraction service."""
-
-    async def _validate() -> None:
-        command = KGCommand(ctx)
-        try:
-            config_manager = command.get_config_manager()
-            config_data = config_manager.get_section("indexer")
-            kg_service = await command._get_kg_service(config_data)
-
-            command.console.print("🔍 Validating extraction service...")
-
-            if await kg_service.validate_extraction_service():
-                command.console.print("[green]✅ Extraction service is working correctly[/green]")
-            else:
-                command.console.print("[red]❌ Extraction service validation failed[/red]")
-                raise typer.Exit(1)
-
-        except Exception as e:
-            command.console.print(f"[red]❌ Validation failed: {e}[/red]")
-            logger.error(f"KG validation failed: {e}")
-            raise typer.Exit(1)
-
-    asyncio.run(_validate())
 
 
 @app.command()

--- a/src/oboyu/ports/services/kg_extraction_service.py
+++ b/src/oboyu/ports/services/kg_extraction_service.py
@@ -72,15 +72,6 @@ class KGExtractionService(ABC):
 
         """
 
-    @abstractmethod
-    async def validate_extraction_schema(self) -> bool:
-        """Validate that the model can produce valid JSON schema output.
-
-        Returns:
-            True if model supports required JSON schema format
-
-        """
-
 
 class ExtractionError(Exception):
     """Exception raised when knowledge graph extraction fails."""


### PR DESCRIPTION
Fixes #307

## 🎯 Problem
The `oboyu kg validate` command performs unnecessary validation that adds complexity to the CLI without significant value. The system now handles initialization automatically on first use, making manual validation redundant.

## 💡 Solution Approach
Completely removed the validate command and associated validation methods from:
- CLI commands (`kg.py`)
- KnowledgeGraphService  
- Extraction service interface and implementations
- Removed skip_validation parameter from build command

## ✅ Completed Changes
- [x] Remove validate command from CLI
- [x] Remove validation methods from service classes
- [x] Update interface to remove validation methods
- [x] Verify no broken references remain
- [x] All tests pass and code quality checks pass

## 🔗 Related
- Issue: #307
- Branch: 307-remove-kg-validate-command

## 📊 Current Status
- Implementation: 100% complete
- Tests: All fast tests pass (4 pre-existing contract test failures unrelated to this change)
- Code quality: All linting, formatting, and type checking passes

Ready for review!