### PR TITLE
Fix #330 - Replace non-existent 'health check' command with 'version' command

### DIFF
--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -65,7 +65,7 @@ jobs:
           
       - name: Run basic functionality test
         run: |
-          test-env/bin/oboyu health check
+          test-env/bin/oboyu version
           
   test-docker-install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #330

## 🎯 Problem
The CI/CD pipeline in `.github/workflows/test-installation.yml` is failing because it attempts to run a non-existent `oboyu health check` command.

## 💡 Solution Approach
Replace the failing `health check` command with the `version` command for basic functionality testing.

## 📋 Progress Checklist
- [ ] Core functionality implemented (replace health check with version)
- [ ] Tests written/updated
- [ ] Documentation updated
- [ ] Code quality checks passed

## 🔗 Related
- Issue: #330
- Branch: 330-fix-ci-health-check-command
- Worktree: /Users/sonesuke/oboyu/main/.worktree/issue-330